### PR TITLE
B12 - createdAt 등이 포함된 BaseEntity를 생성한다. 

### DIFF
--- a/backend/src/main/java/botobo/core/BotoboApplication.java
+++ b/backend/src/main/java/botobo/core/BotoboApplication.java
@@ -2,8 +2,10 @@ package botobo.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BotoboApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/botobo/core/quiz/domain/BaseEntity.java
+++ b/backend/src/main/java/botobo/core/quiz/domain/BaseEntity.java
@@ -1,0 +1,26 @@
+package botobo.core.quiz.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/botobo/core/quiz/domain/answer/Answer.java
+++ b/backend/src/main/java/botobo/core/quiz/domain/answer/Answer.java
@@ -1,5 +1,6 @@
 package botobo.core.quiz.domain.answer;
 
+import botobo.core.quiz.domain.BaseEntity;
 import botobo.core.quiz.domain.card.Card;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,11 +12,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @Getter
 @Entity
-public class Answer {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Answer extends BaseEntity {
 
     @Lob
     @Column(nullable = false)

--- a/backend/src/main/java/botobo/core/quiz/domain/card/Card.java
+++ b/backend/src/main/java/botobo/core/quiz/domain/card/Card.java
@@ -1,5 +1,6 @@
 package botobo.core.quiz.domain.card;
 
+import botobo.core.quiz.domain.BaseEntity;
 import botobo.core.quiz.domain.answer.Answers;
 import botobo.core.quiz.domain.category.Category;
 import lombok.Builder;
@@ -12,11 +13,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @Getter
 @Entity
-public class Card {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Card extends BaseEntity {
 
     @Lob
     @Column(nullable = false)

--- a/backend/src/main/java/botobo/core/quiz/domain/category/Category.java
+++ b/backend/src/main/java/botobo/core/quiz/domain/category/Category.java
@@ -1,5 +1,6 @@
 package botobo.core.quiz.domain.category;
 
+import botobo.core.quiz.domain.BaseEntity;
 import botobo.core.quiz.domain.card.Card;
 import botobo.core.quiz.domain.card.Cards;
 import lombok.Builder;
@@ -13,11 +14,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @Getter
 @Entity
-public class Category {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Category extends BaseEntity {
 
     @Column(nullable = false, length = 30, unique = true)
     private String name;

--- a/backend/src/test/java/botobo/core/documentation/CategoryDocumentationTest.java
+++ b/backend/src/test/java/botobo/core/documentation/CategoryDocumentationTest.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
@@ -24,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("카테고리 문서화 테스트")
 @WebMvcTest(CategoryController.class)
 @AutoConfigureRestDocs
+@MockBean(JpaMetamodelMappingContext.class)
 public class CategoryDocumentationTest {
 
     @Autowired

--- a/backend/src/test/java/botobo/core/documentation/QuizDocumentationTest.java
+++ b/backend/src/test/java/botobo/core/documentation/QuizDocumentationTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(QuizController.class)
 @AutoConfigureRestDocs
+@MockBean(JpaMetamodelMappingContext.class)
 public class QuizDocumentationTest {
 
     @Autowired

--- a/backend/src/test/java/botobo/core/quiz/domain/AnswerRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/quiz/domain/AnswerRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +71,8 @@ class AnswerRepositoryTest {
         // then
         assertThat(savedAnswer).extracting("id").isNotNull();
         assertThat(savedAnswer).isSameAs(answer);
+        assertThat(savedAnswer.getCreatedAt()).isNotNull();
+        assertThat(savedAnswer.getUpdatedAt()).isNotNull();
     }
 
     @Test

--- a/backend/src/test/java/botobo/core/quiz/domain/CardRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/quiz/domain/CardRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +56,9 @@ class CardRepositoryTest {
 
         // then
         assertThat(savedCard.getId()).isNotNull();
+        assertThat(savedCard).isSameAs(card);
+        assertThat(savedCard.getCreatedAt()).isNotNull();
+        assertThat(savedCard.getUpdatedAt()).isNotNull();
     }
 
     @Test

--- a/backend/src/test/java/botobo/core/quiz/domain/CategoryRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/quiz/domain/CategoryRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -48,6 +49,8 @@ public class CategoryRepositoryTest {
         assertThat(category.getId()).isNotNull();
         assertThat(savedCategory).extracting("id").isNotNull();
         assertThat(savedCategory).isSameAs(category);
+        assertThat(savedCategory.getCreatedAt()).isNotNull();
+        assertThat(savedCategory.getUpdatedAt()).isNotNull();
         testEntityManager.flush();
     }
 


### PR DESCRIPTION
closes #50 

## 작업 내용
- 일단 필요하다고 생각된 공통 필드인 id, createdAt, updatedAt을 BaseEntity 추상클래스로 추출했습니다.
- @EntityListener와 @EnableJpaAuditing을 이용해 자동으로 영속화 또는 수정될 때 createdAt과 updatedAt이 추가되도록 하였습니다.

## 주의 사항
- id의 경우 하위 클래스에서 모두 생성자 만들때 사용하고 있다보니 private으로 접근이 불가하여 protected로 고쳤는데 이건 아니다 싶으면 id는 하위 클래스가 private으로 가지고 있도록 수정해도 괜찮을 것 같습니다.
- @EnableJpaAuditing을 BotoboApplication 위에 추가하니 @WebMvcTest를 명시한 문서화 테스트에서 에러가 발생했습니다. @WebMvcTest를 이용해 슬라이스 테스트를 하다보니 @EnableJpaAuditing의 영향으로 JPA 관련 Bean이 필요한데 들고오지 못하여 발생한 오류라고 찾아보니 나오더군요..ㅎㅎ; 그래서 각각의 문서화 테스트에 @MockBean(JpaMetamodelMappingContext.class)을 추가해두었습니다.
- 이를 해결하기 위한 방법으로 따로 JpaConfig를 만들어 @EnableJpaAuditing을 명시하는 방식도 있다고 합니다. 다만, 그렇게 하니 RepositoryTest에서 @EnableJpaAuditing가 작동하지 않아서 에러가 발생했습니다. 이유는 이것도 마찬가지로 슬라이스 테스트라 Config 관련 클래스를 가져오지 않아서 발생하는 오류입니다.

그래서 요점은 이것입니당
1. BotoboApplication 위에 @EnableJpaAuditing을 추가 (이에 따라 문서화 테스트에 전부 @MockBean(JpaMetamodelMappingContext.class)을 추가해야함)
2. JpaConfig 클래스를 만들어 @Configuration과 @EnableJpaAuditing을 추가 (이에 따라 createdAt 또는 updatedAt이 있는 엔티티 RepositoryTest를 전부 @DataJpaTest(includeFilters = @ComponentScan.Filter(
        type = FilterType.ASSIGNABLE_TYPE,
        classes = JpaConfig.class
)) 로 수정해야함)

더 나은 방법이 있을 수도 있으나 제가 찾아본 건 요정도였습니다.
일단 지금은 문서화 테스트에 전부 @MockBean(JpaMetamodelMappingContext.class)을 추가했으나 수정이 가능하니 리뷰 부탁드립니다.
