### PR TITLE
U03 - 로그인 한 사용자와 관련있는 /users/me api 및 User 테스트를 추가한다. 

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -12,3 +12,5 @@ include::quizzes.adoc[]
 include::admin.adoc[]
 
 include::login.adoc[]
+
+include::user.adoc[]

--- a/backend/src/docs/asciidoc/user.adoc
+++ b/backend/src/docs/asciidoc/user.adoc
@@ -1,0 +1,7 @@
+== 유저 API
+
+=== 로그인 한 유저 정보 조회 요청
+==== 요청
+include::{snippets}/users-find-me-get-success/http-request.adoc[]
+==== 응답
+include::{snippets}/users-find-me-get-success/http-response.adoc[]

--- a/backend/src/main/java/botobo/core/auth/exception/GithubApiFailedException.java
+++ b/backend/src/main/java/botobo/core/auth/exception/GithubApiFailedException.java
@@ -1,6 +1,6 @@
 package botobo.core.auth.exception;
 
-import botobo.core.exception.UnauthorizedException;
+import botobo.core.common.exception.UnauthorizedException;
 
 public class GithubApiFailedException extends UnauthorizedException {
 

--- a/backend/src/main/java/botobo/core/auth/exception/UserProfileLoadFailedException.java
+++ b/backend/src/main/java/botobo/core/auth/exception/UserProfileLoadFailedException.java
@@ -1,6 +1,6 @@
 package botobo.core.auth.exception;
 
-import botobo.core.exception.UnauthorizedException;
+import botobo.core.common.exception.UnauthorizedException;
 
 public class UserProfileLoadFailedException extends UnauthorizedException {
 

--- a/backend/src/main/java/botobo/core/auth/infrastructure/AuthorizationExtractor.java
+++ b/backend/src/main/java/botobo/core/auth/infrastructure/AuthorizationExtractor.java
@@ -1,6 +1,6 @@
 package botobo.core.auth.infrastructure;
 
-import botobo.core.exception.UnauthorizedException;
+import botobo.core.common.exception.UnauthorizedException;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Enumeration;

--- a/backend/src/main/java/botobo/core/auth/ui/AuthenticationPrincipal.java
+++ b/backend/src/main/java/botobo/core/auth/ui/AuthenticationPrincipal.java
@@ -1,0 +1,12 @@
+package botobo.core.auth.ui;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+}
+

--- a/backend/src/main/java/botobo/core/auth/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/botobo/core/auth/ui/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,35 @@
+package botobo.core.auth.ui;
+
+import botobo.core.auth.infrastructure.AuthorizationExtractor;
+import botobo.core.auth.infrastructure.JwtTokenProvider;
+import botobo.core.user.domain.LoginUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthenticationPrincipalArgumentResolver(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String credentials = AuthorizationExtractor.extract(webRequest.getNativeRequest(HttpServletRequest.class));
+        Long userId = jwtTokenProvider.getIdFromPayLoad(credentials);
+        return LoginUser.builder()
+                .id(userId)
+                .build();
+    }
+}

--- a/backend/src/main/java/botobo/core/auth/ui/AuthorizationInterceptor.java
+++ b/backend/src/main/java/botobo/core/auth/ui/AuthorizationInterceptor.java
@@ -2,7 +2,7 @@ package botobo.core.auth.ui;
 
 import botobo.core.auth.infrastructure.AuthorizationExtractor;
 import botobo.core.auth.infrastructure.JwtTokenProvider;
-import botobo.core.exception.UnauthorizedException;
+import botobo.core.common.exception.UnauthorizedException;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 

--- a/backend/src/main/java/botobo/core/common/domain/BaseEntity.java
+++ b/backend/src/main/java/botobo/core/common/domain/BaseEntity.java
@@ -1,4 +1,4 @@
-package botobo.core.quiz.domain;
+package botobo.core.common.domain;
 
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;

--- a/backend/src/main/java/botobo/core/common/exception/ErrorResponse.java
+++ b/backend/src/main/java/botobo/core/common/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package botobo.core.exception;
+package botobo.core.common.exception;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/botobo/core/common/exception/GlobalControllerAdvice.java
+++ b/backend/src/main/java/botobo/core/common/exception/GlobalControllerAdvice.java
@@ -1,4 +1,4 @@
-package botobo.core.exception;
+package botobo.core.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;

--- a/backend/src/main/java/botobo/core/common/exception/NotFoundException.java
+++ b/backend/src/main/java/botobo/core/common/exception/NotFoundException.java
@@ -1,4 +1,4 @@
-package botobo.core.exception;
+package botobo.core.common.exception;
 
 public class NotFoundException extends RuntimeException {
     public NotFoundException() {

--- a/backend/src/main/java/botobo/core/common/exception/UnauthorizedException.java
+++ b/backend/src/main/java/botobo/core/common/exception/UnauthorizedException.java
@@ -1,4 +1,4 @@
-package botobo.core.exception;
+package botobo.core.common.exception;
 
 public class UnauthorizedException extends RuntimeException {
 

--- a/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
@@ -1,18 +1,22 @@
 package botobo.core.config;
 
 import botobo.core.auth.infrastructure.JwtTokenProvider;
+import botobo.core.auth.ui.AuthenticationPrincipalArgumentResolver;
 import botobo.core.auth.ui.AuthorizationInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
-public class AuthenticationConfig implements WebMvcConfigurer {
+public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthenticationConfig(JwtTokenProvider jwtTokenProvider) {
+    public AuthenticationPrincipalConfig(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
@@ -20,11 +24,21 @@ public class AuthenticationConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor())
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/login", "/api/quizzes/guest");
+                .excludePathPatterns("/api/login", "/api/quizzes/guest", "/api/users/me");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationPrincipalArgumentResolver());
     }
 
     @Bean
     public AuthorizationInterceptor authorizationInterceptor() {
         return new AuthorizationInterceptor(jwtTokenProvider);
+    }
+
+    @Bean
+    public AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver() {
+        return new AuthenticationPrincipalArgumentResolver(jwtTokenProvider);
     }
 }

--- a/backend/src/main/java/botobo/core/quiz/domain/card/Card.java
+++ b/backend/src/main/java/botobo/core/quiz/domain/card/Card.java
@@ -1,6 +1,6 @@
 package botobo.core.quiz.domain.card;
 
-import botobo.core.quiz.domain.BaseEntity;
+import botobo.core.common.domain.BaseEntity;
 import botobo.core.quiz.domain.workbook.Workbook;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/botobo/core/quiz/domain/workbook/Workbook.java
+++ b/backend/src/main/java/botobo/core/quiz/domain/workbook/Workbook.java
@@ -1,6 +1,6 @@
 package botobo.core.quiz.domain.workbook;
 
-import botobo.core.quiz.domain.BaseEntity;
+import botobo.core.common.domain.BaseEntity;
 import botobo.core.quiz.domain.card.Card;
 import botobo.core.quiz.domain.card.Cards;
 import botobo.core.quiz.exception.CardNotFoundException;

--- a/backend/src/main/java/botobo/core/quiz/exception/CardNotFoundException.java
+++ b/backend/src/main/java/botobo/core/quiz/exception/CardNotFoundException.java
@@ -1,6 +1,6 @@
 package botobo.core.quiz.exception;
 
-import botobo.core.exception.NotFoundException;
+import botobo.core.common.exception.NotFoundException;
 
 public class CardNotFoundException extends NotFoundException {
     public CardNotFoundException() {

--- a/backend/src/main/java/botobo/core/quiz/exception/WorkbookNotFoundException.java
+++ b/backend/src/main/java/botobo/core/quiz/exception/WorkbookNotFoundException.java
@@ -1,6 +1,6 @@
 package botobo.core.quiz.exception;
 
-import botobo.core.exception.NotFoundException;
+import botobo.core.common.exception.NotFoundException;
 
 public class WorkbookNotFoundException extends NotFoundException {
     public WorkbookNotFoundException() {

--- a/backend/src/main/java/botobo/core/user/application/UserService.java
+++ b/backend/src/main/java/botobo/core/user/application/UserService.java
@@ -1,0 +1,29 @@
+package botobo.core.user.application;
+
+import botobo.core.user.domain.User;
+import botobo.core.user.domain.UserRepository;
+import botobo.core.user.dto.UserResponse;
+import botobo.core.user.exception.UserNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserResponse findById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(UserNotFoundException::new);
+        return UserResponse.builder()
+                .id(user.getId())
+                .userName(user.getUserName())
+                .profileUrl(user.getProfileUrl())
+                .build();
+    }
+}

--- a/backend/src/main/java/botobo/core/user/domain/LoginUser.java
+++ b/backend/src/main/java/botobo/core/user/domain/LoginUser.java
@@ -1,0 +1,14 @@
+package botobo.core.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginUser {
+    private Long id;
+}

--- a/backend/src/main/java/botobo/core/user/domain/User.java
+++ b/backend/src/main/java/botobo/core/user/domain/User.java
@@ -1,10 +1,12 @@
 package botobo.core.user.domain;
 
+import botobo.core.common.domain.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -15,11 +17,17 @@ import javax.persistence.Id;
 @AllArgsConstructor
 @Builder
 @Entity
-public class User {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private Long githubId;
+
+    @Column(nullable = false)
     private String userName;
+
+    @Column(nullable = false)
     private String profileUrl;
 }

--- a/backend/src/main/java/botobo/core/user/dto/UserResponse.java
+++ b/backend/src/main/java/botobo/core/user/dto/UserResponse.java
@@ -1,0 +1,17 @@
+package botobo.core.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponse {
+
+    private Long id;
+    private String userName;
+    private String profileUrl;
+}

--- a/backend/src/main/java/botobo/core/user/exception/UserNotFoundException.java
+++ b/backend/src/main/java/botobo/core/user/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package botobo.core.user.exception;
+
+import botobo.core.common.exception.NotFoundException;
+
+public class UserNotFoundException extends NotFoundException {
+    public UserNotFoundException() {
+        super("해당 유저를 찾을 수 없습니다.");
+    }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/botobo/core/user/ui/UserController.java
+++ b/backend/src/main/java/botobo/core/user/ui/UserController.java
@@ -1,0 +1,27 @@
+package botobo.core.user.ui;
+
+import botobo.core.auth.ui.AuthenticationPrincipal;
+import botobo.core.user.application.UserService;
+import botobo.core.user.domain.LoginUser;
+import botobo.core.user.dto.UserResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> findUserOfMine(@AuthenticationPrincipal LoginUser loginUser) {
+        UserResponse userResponse = userService.findById(loginUser.getId());
+        return ResponseEntity.ok(userResponse);
+    }
+}

--- a/backend/src/test/java/botobo/core/admin/AdminAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/admin/AdminAcceptanceTest.java
@@ -5,7 +5,7 @@ import botobo.core.admin.dto.AdminCardResponse;
 import botobo.core.admin.dto.AdminWorkbookRequest;
 import botobo.core.admin.dto.AdminWorkbookResponse;
 import botobo.core.auth.AuthAcceptanceTest;
-import botobo.core.exception.ErrorResponse;
+import botobo.core.common.exception.ErrorResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;

--- a/backend/src/test/java/botobo/core/documentation/UserDocumentationTest.java
+++ b/backend/src/test/java/botobo/core/documentation/UserDocumentationTest.java
@@ -1,0 +1,65 @@
+package botobo.core.documentation;
+
+import botobo.core.auth.infrastructure.JwtTokenProvider;
+import botobo.core.user.application.UserService;
+import botobo.core.user.dto.UserResponse;
+import botobo.core.user.ui.UserController;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static botobo.core.documentation.DocumentationUtils.getDocumentRequest;
+import static botobo.core.documentation.DocumentationUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@DisplayName("유저용 API 문서화 테스트")
+@WebMvcTest(UserController.class)
+@AutoConfigureRestDocs
+@MockBean(JpaMetamodelMappingContext.class)
+public class UserDocumentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("현재 로그인 한 유저 조회 - 성공")
+    void findUserOfMine() throws Exception {
+        String token = "botobo.access.token";
+        UserResponse userResponse = UserResponse.builder()
+                .id(1L)
+                .userName("user")
+                .profileUrl("profile.io")
+                .build();
+
+        given(jwtTokenProvider.isValidToken(token)).willReturn(true);
+        given(userService.findById(anyLong())).willReturn(userResponse);
+
+        mockMvc.perform(get("/api/users/me")
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andDo(document("users-find-me-get-success",
+                        getDocumentRequest(),
+                        getDocumentResponse())
+                );
+    }
+}

--- a/backend/src/test/java/botobo/core/quiz/QuizAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/quiz/QuizAcceptanceTest.java
@@ -3,7 +3,7 @@ package botobo.core.quiz;
 import botobo.core.admin.dto.AdminCardRequest;
 import botobo.core.admin.dto.AdminWorkbookRequest;
 import botobo.core.auth.AuthAcceptanceTest;
-import botobo.core.exception.ErrorResponse;
+import botobo.core.common.exception.ErrorResponse;
 import botobo.core.quiz.dto.QuizRequest;
 import botobo.core.quiz.dto.QuizResponse;
 import io.restassured.RestAssured;

--- a/backend/src/test/java/botobo/core/quiz/domain/card/CardRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/quiz/domain/card/CardRepositoryTest.java
@@ -1,7 +1,5 @@
-package botobo.core.quiz.domain;
+package botobo.core.quiz.domain.card;
 
-import botobo.core.quiz.domain.card.Card;
-import botobo.core.quiz.domain.card.CardRepository;
 import botobo.core.quiz.domain.workbook.Workbook;
 import botobo.core.quiz.domain.workbook.WorkbookRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/backend/src/test/java/botobo/core/quiz/domain/card/CardTest.java
+++ b/backend/src/test/java/botobo/core/quiz/domain/card/CardTest.java
@@ -1,4 +1,4 @@
-package botobo.core.quiz.domain;
+package botobo.core.quiz.domain.card;
 
 import botobo.core.quiz.domain.card.Card;
 import botobo.core.quiz.domain.workbook.Workbook;

--- a/backend/src/test/java/botobo/core/quiz/domain/workbook/WorkbookRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/quiz/domain/workbook/WorkbookRepositoryTest.java
@@ -1,7 +1,5 @@
-package botobo.core.quiz.domain;
+package botobo.core.quiz.domain.workbook;
 
-import botobo.core.quiz.domain.workbook.Workbook;
-import botobo.core.quiz.domain.workbook.WorkbookRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,20 +39,6 @@ public class WorkbookRepositoryTest {
         assertThat(savedWorkbook.getUpdatedAt()).isNotNull();
         testEntityManager.flush();
     }
-
-//    @Test
-//    @DisplayName("Workbook 저장 - 실패, 이름이 최대 길이를 초과")
-//    void saveWithLongName() {
-//        // given
-//        Workbook workbook = Workbook.builder()
-//                .name("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")
-//                .isDeleted(false)
-//                .build();
-//
-//        // when, then
-//        assertThatThrownBy(() -> workbookRepository.save(workbook))
-//                .isInstanceOf(DataIntegrityViolationException.class);
-//    }
 
     @Test
     @DisplayName("Workbook id로 조회 - 성공")

--- a/backend/src/test/java/botobo/core/user/UserAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/user/UserAcceptanceTest.java
@@ -1,0 +1,55 @@
+package botobo.core.user;
+
+import botobo.core.auth.AuthAcceptanceTest;
+import botobo.core.common.exception.ErrorResponse;
+import botobo.core.user.dto.UserResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserAcceptanceTest extends AuthAcceptanceTest {
+
+    @Test
+    @DisplayName("로그인 한 유저의 정보를 가져온다. - 성공")
+    void findByUserOfMine() {
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(로그인되어_있음().getAccessToken())
+                .when().get("/api/users/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+        UserResponse userResponse = response.as(UserResponse.class);
+
+        //then
+        assertThat(userResponse.getId()).isNotNull();
+        assertThat(userResponse.getUserName()).isEqualTo("githubUser");
+        assertThat(userResponse.getProfileUrl()).isEqualTo("github.io");
+    }
+
+    @Test
+    @DisplayName("로그인 한 유저의 정보를 가져온다. - 실패, 토큰이 없을 경우")
+    void findByUserOfMineWhenNotExistToken() {
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/api/users/me")
+                .then().log().all()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .extract();
+
+        ErrorResponse errorResponse = response.as(ErrorResponse.class);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(errorResponse.getMessage()).isEqualTo("토큰 추출에 실패했습니다.");
+    }
+}

--- a/backend/src/test/java/botobo/core/user/application/UserServiceTest.java
+++ b/backend/src/test/java/botobo/core/user/application/UserServiceTest.java
@@ -1,0 +1,55 @@
+package botobo.core.user.application;
+
+import botobo.core.user.domain.User;
+import botobo.core.user.domain.UserRepository;
+import botobo.core.user.dto.UserResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@DisplayName("유저 서비스 테스트")
+@MockitoSettings
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("유저 id에 해당하는 유저를 조회한다. - 성공")
+    void findById() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .githubId(1L)
+                .userName("user")
+                .profileUrl("profile.io")
+                .build();
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+
+        // when
+        UserResponse userResponse = userService.findById(user.getId());
+
+        // then
+        assertThat(userResponse.getId()).isEqualTo(user.getId());
+        assertThat(userResponse.getUserName()).isEqualTo(user.getUserName());
+        assertThat(userResponse.getProfileUrl()).isEqualTo(user.getProfileUrl());
+
+        then(userRepository)
+                .should(times(1))
+                .findById(anyLong());
+    }
+}

--- a/backend/src/test/java/botobo/core/user/domain/UserRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/user/domain/UserRepositoryTest.java
@@ -1,0 +1,69 @@
+package botobo.core.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("User 저장 - 성공")
+    void save() {
+        // given
+        User user = User.builder()
+                .githubId(1L)
+                .userName("user")
+                .profileUrl("profile.io")
+                .build();
+
+        // when
+        User savedUser = userRepository.save(user);
+
+        // then
+        assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser).isSameAs(user);
+        assertThat(savedUser.getCreatedAt()).isNotNull();
+        assertThat(savedUser.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("User id로 조회 - 성공")
+    void findById() {
+        // given
+        User user = User.builder()
+                .githubId(1L)
+                .userName("user")
+                .profileUrl("profile.io")
+                .build();
+        User savedUser = userRepository.save(user);
+
+        // when, then
+        Optional<User> findUser = userRepository.findById(savedUser.getId());
+        assertThat(findUser).containsSame(savedUser);
+    }
+
+    @Test
+    @DisplayName("User Github Id로 조회 - 성공")
+    void findByGithubId() {
+        // given
+        User user = User.builder()
+                .githubId(1L)
+                .userName("user")
+                .profileUrl("profile.io")
+                .build();
+        userRepository.save(user);
+
+        // when, then
+        Optional<User> findUser = userRepository.findByGithubId(user.getGithubId());
+        assertThat(findUser).containsSame(user);
+    }
+}

--- a/backend/src/test/java/botobo/core/user/domain/UserTest.java
+++ b/backend/src/test/java/botobo/core/user/domain/UserTest.java
@@ -1,0 +1,21 @@
+package botobo.core.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class UserTest {
+
+    @Test
+    @DisplayName("Builder를 이용한 User 객체 생성 - 성공")
+    void createWithBuilder() {
+        assertThatCode(() -> User.builder()
+                .id(1L)
+                .githubId(1L)
+                .userName("user")
+                .profileUrl("profile.io")
+                .build()
+        ).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
closes #169 

## 작업 내용
- 유저의 정보를 가져오는 GET /users/me api를 추가했습니다.
- User 관련 테스트를 추가하였습니다. 
- 기존의 BaseEntity가 quiz 도메인 패키지에 위치해 있었는데 User에도 사용을 하므로 공통으로 빼는게 좋을거 같다고 생각했습니다. 때마침 외부에 있던 exception 패키지도 마찬가지로 공통으로 사용하는 성격을 가졌기에 이를 묶어 common 패키지를 만들었습니다. 변경 가능하니 리뷰 부탁드립니다.

## 주의 사항
- /users/me를 이용한 유저 수정 또는 삭제와 같은 api는 후에 고려하면 되므로 따로 추가하지 않았습니다. 