### PR TITLE
B32 - api 문서의 위치를 api/docs 경로로 옮긴다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ logs/**
 
 
 ### API Documentation ###
-backend/src/main/resources/static/docs/**
+backend/src/main/resources/static/api/docs/**
 
 ### Secret files ###
 backend/src/main/resources/application-dev.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -70,7 +70,7 @@ test {
 }
 
 asciidoctor.doFirst {
-    delete file('src/main/resources/static/docs')
+    delete file('src/main/resources/static/api/docs')
 }
 
 asciidoctor {
@@ -82,7 +82,7 @@ task createDocument(type: Copy) {
     dependsOn asciidoctor
 
     from file("build/asciidoc/html5/index.html")
-    into file("src/main/resources/static/docs")
+    into file("src/main/resources/static/api/docs")
 }
 
 build {

--- a/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
@@ -24,7 +24,7 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor())
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/login", "/api/quizzes/guest");
+                .excludePathPatterns("/api/login", "/api/quizzes/guest", "/api/docs/**");
     }
 
     @Override


### PR DESCRIPTION
closes #211 

## 작업 내용
백엔드 경로에 /api 가 추가되면서 문서 경로도 기존 `/docs/index.html` 에서 `/api/docs/index.html`로 바꿨습니다.

## 주의 사항
없음