### PR TITLE
B33 - Update, Delete method CORS 처리 추가

### DIFF
--- a/backend/src/main/java/botobo/core/config/WebConfig.java
+++ b/backend/src/main/java/botobo/core/config/WebConfig.java
@@ -15,6 +15,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .maxAge(3000);
     }
 


### PR DESCRIPTION
closes #242 

## 작업 내용
기존 addCorsMapping에 allowedMethods를 따로 명시해주지 않았는데, 찾아보니 default가 GET, POST, HEAD 더라구용!
그래서 UPDATE, DELETE도 허용하도록 추가했습니다 ~

* ref: javadoc of allowedMethods
> Set the HTTP methods to allow, e.g. "GET", "POST", etc.  
> By default "simple" methods GET, HEAD, and POST are allowed.  

## 주의 사항
없음.