### PR TITLE
B41 - 경로와 HttpMethod를 이용해 인터셉터 설정 가능하도록 수정 및 /api/workbooks 경로를 인터셉터에 추가한다.

### DIFF
--- a/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
@@ -4,9 +4,12 @@ import botobo.core.application.AuthService;
 import botobo.core.ui.auth.AdminInterceptor;
 import botobo.core.ui.auth.AuthenticationPrincipalArgumentResolver;
 import botobo.core.ui.auth.AuthorizationInterceptor;
+import botobo.core.ui.auth.PathMatcherInterceptor;
+import botobo.core.ui.auth.PathMethod;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -43,11 +46,20 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authorizationInterceptor())
-                .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/login", "/api/quizzes/guest", "/api/docs/**", "/api/workbooks", "/api/workbooks/public/**");
+        HandlerInterceptor authorizationInterceptor = new PathMatcherInterceptor(authorizationInterceptor())
+                .addPathPatterns("/api/**", PathMethod.ANY)
+                .excludePathPatterns("/api/**", PathMethod.OPTIONS)
+                .excludePathPatterns("/api/workbooks", PathMethod.GET)
+                .excludePathPatterns("/api/quizzes/guest", PathMethod.GET)
+                .excludePathPatterns("/api/login", PathMethod.POST)
+                .excludePathPatterns("/api/docs/**", PathMethod.ANY)
+                .excludePathPatterns("/api/workbooks/public/**", PathMethod.GET);
+        registry.addInterceptor(authorizationInterceptor);
 
-        registry.addInterceptor(adminInterceptor())
-                .addPathPatterns("/api/admin/**");
+        HandlerInterceptor adminInterceptor = new PathMatcherInterceptor(adminInterceptor())
+                .addPathPatterns("/api/admin/workbooks", PathMethod.POST)
+                .addPathPatterns("/api/admin/cards", PathMethod.POST)
+                .excludePathPatterns("/api/**", PathMethod.OPTIONS);
+        registry.addInterceptor(adminInterceptor);
     }
 }

--- a/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/botobo/core/config/AuthenticationPrincipalConfig.java
@@ -9,7 +9,6 @@ import botobo.core.ui.auth.PathMethod;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -46,7 +45,13 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        HandlerInterceptor authorizationInterceptor = new PathMatcherInterceptor(authorizationInterceptor())
+        registry.addInterceptor(authPathMatcherInterceptor());
+        registry.addInterceptor(adminPathMatcherInterceptor());
+    }
+
+    @Bean
+    public PathMatcherInterceptor authPathMatcherInterceptor() {
+        return new PathMatcherInterceptor(authorizationInterceptor())
                 .addPathPatterns("/api/**", PathMethod.ANY)
                 .excludePathPatterns("/api/**", PathMethod.OPTIONS)
                 .excludePathPatterns("/api/workbooks", PathMethod.GET)
@@ -54,12 +59,13 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/api/login", PathMethod.POST)
                 .excludePathPatterns("/api/docs/**", PathMethod.ANY)
                 .excludePathPatterns("/api/workbooks/public/**", PathMethod.GET);
-        registry.addInterceptor(authorizationInterceptor);
+    }
 
-        HandlerInterceptor adminInterceptor = new PathMatcherInterceptor(adminInterceptor())
+    @Bean
+    public PathMatcherInterceptor adminPathMatcherInterceptor() {
+        return new PathMatcherInterceptor(adminInterceptor())
                 .addPathPatterns("/api/admin/workbooks", PathMethod.POST)
                 .addPathPatterns("/api/admin/cards", PathMethod.POST)
                 .excludePathPatterns("/api/**", PathMethod.OPTIONS);
-        registry.addInterceptor(adminInterceptor);
     }
 }

--- a/backend/src/main/java/botobo/core/ui/auth/AdminInterceptor.java
+++ b/backend/src/main/java/botobo/core/ui/auth/AdminInterceptor.java
@@ -2,7 +2,6 @@ package botobo.core.ui.auth;
 
 import botobo.core.application.AuthService;
 import botobo.core.infrastructure.AuthorizationExtractor;
-import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,9 +17,6 @@ public class AdminInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        if (CorsUtils.isPreFlightRequest(request)) {
-            return true;
-        }
         String credentials = AuthorizationExtractor.extract(request);
         authService.validateAdmin(credentials);
         return true;

--- a/backend/src/main/java/botobo/core/ui/auth/AuthorizationInterceptor.java
+++ b/backend/src/main/java/botobo/core/ui/auth/AuthorizationInterceptor.java
@@ -2,7 +2,6 @@ package botobo.core.ui.auth;
 
 import botobo.core.application.AuthService;
 import botobo.core.infrastructure.AuthorizationExtractor;
-import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,9 +17,6 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        if (CorsUtils.isPreFlightRequest(request)) {
-            return true;
-        }
         String credentials = AuthorizationExtractor.extract(request);
         authService.validateToken(credentials);
         return true;

--- a/backend/src/main/java/botobo/core/ui/auth/PathMatcherInterceptor.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathMatcherInterceptor.java
@@ -29,7 +29,7 @@ public class PathMatcherInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String uri = request.getRequestURI();
         String httpMethod = request.getMethod();
-        if (pathPatterns.isExcludedPath(uri, httpMethod)) {
+        if (pathPatterns.isExcludedPath(uri, PathMethod.of(httpMethod))) {
             return true;
         }
         return handlerInterceptor.preHandle(request, response, handler);

--- a/backend/src/main/java/botobo/core/ui/auth/PathMatcherInterceptor.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathMatcherInterceptor.java
@@ -1,0 +1,47 @@
+package botobo.core.ui.auth;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class PathMatcherInterceptor implements HandlerInterceptor {
+    private final HandlerInterceptor handlerInterceptor;
+    private final PathPatterns pathPatterns;
+
+    public PathMatcherInterceptor(HandlerInterceptor handlerInterceptor) {
+        this.handlerInterceptor = handlerInterceptor;
+        this.pathPatterns = new PathPatterns();
+    }
+
+    public PathMatcherInterceptor addPathPatterns(String pathPattern, PathMethod... pathMethods) {
+        pathPatterns.addPathPatterns(pathPattern, pathMethods);
+        return this;
+    }
+
+    public PathMatcherInterceptor excludePathPatterns(String pathPattern, PathMethod... pathMethods) {
+        pathPatterns.excludePathPatterns(pathPattern, pathMethods);
+        return this;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String uri = request.getRequestURI();
+        String httpMethod = request.getMethod();
+        if (pathPatterns.isExcludedPath(uri, httpMethod)) {
+            return true;
+        }
+        return handlerInterceptor.preHandle(request, response, handler);
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        handlerInterceptor.postHandle(request, response, handler, modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        handlerInterceptor.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/backend/src/main/java/botobo/core/ui/auth/PathMethod.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathMethod.java
@@ -1,0 +1,9 @@
+package botobo.core.ui.auth;
+
+public enum PathMethod {
+    GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE, ANY;
+
+    public boolean match(String httpMethod) {
+        return this.name().equals(httpMethod);
+    }
+}

--- a/backend/src/main/java/botobo/core/ui/auth/PathMethod.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathMethod.java
@@ -1,9 +1,18 @@
 package botobo.core.ui.auth;
 
+import java.util.Arrays;
+
 public enum PathMethod {
     GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE, ANY;
 
-    public boolean match(String httpMethod) {
+    public static PathMethod of(String httpMethod) {
+        return Arrays.stream(values())
+                .filter(pathMethod -> pathMethod.match(httpMethod))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 PathMethod 입니다."));
+    }
+
+    private boolean match(String httpMethod) {
         return this.name().equals(httpMethod);
     }
 }

--- a/backend/src/main/java/botobo/core/ui/auth/PathMethods.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathMethods.java
@@ -1,0 +1,19 @@
+package botobo.core.ui.auth;
+
+import java.util.List;
+
+public class PathMethods {
+    private final List<PathMethod> pathMethods;
+
+    public PathMethods(List<PathMethod> pathMethods) {
+        this.pathMethods = pathMethods;
+    }
+
+    public boolean match(String httpMethod) {
+        if (pathMethods.contains(PathMethod.ANY)) {
+            return true;
+        }
+        return pathMethods.stream()
+                .anyMatch(pathMethod -> pathMethod.match(httpMethod));
+    }
+}

--- a/backend/src/main/java/botobo/core/ui/auth/PathMethods.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathMethods.java
@@ -9,11 +9,10 @@ public class PathMethods {
         this.pathMethods = pathMethods;
     }
 
-    public boolean match(String httpMethod) {
+    public boolean contains(PathMethod pathMethod) {
         if (pathMethods.contains(PathMethod.ANY)) {
             return true;
         }
-        return pathMethods.stream()
-                .anyMatch(pathMethod -> pathMethod.match(httpMethod));
+        return pathMethods.contains(pathMethod);
     }
 }

--- a/backend/src/main/java/botobo/core/ui/auth/PathMethods.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathMethods.java
@@ -1,11 +1,11 @@
 package botobo.core.ui.auth;
 
-import java.util.List;
+import java.util.Set;
 
 public class PathMethods {
-    private final List<PathMethod> pathMethods;
+    private final Set<PathMethod> pathMethods;
 
-    public PathMethods(List<PathMethod> pathMethods) {
+    public PathMethods(Set<PathMethod> pathMethods) {
         this.pathMethods = pathMethods;
     }
 

--- a/backend/src/main/java/botobo/core/ui/auth/PathPatterns.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathPatterns.java
@@ -26,13 +26,13 @@ public class PathPatterns {
         excludePatterns.put(pathPattern, new PathMethods(Arrays.asList(pathMethods)));
     }
 
-    public boolean isExcludedPath(String uri, String httpMethod) {
-        return matchPatterns(excludePatterns, uri, httpMethod) || !matchPatterns(includePatterns, uri, httpMethod);
+    public boolean isExcludedPath(String uri, PathMethod pathMethod) {
+        return matchPatterns(excludePatterns, uri, pathMethod) || !matchPatterns(includePatterns, uri, pathMethod);
     }
 
-    private boolean matchPatterns(Map<String, PathMethods> patterns, String uri, String httpMethod) {
+    private boolean matchPatterns(Map<String, PathMethods> patterns, String uri, PathMethod pathMethod) {
         return patterns.keySet().stream()
                 .filter(pattern -> pathMatcher.match(pattern, uri))
-                .anyMatch(pattern -> patterns.get(pattern).match(httpMethod));
+                .anyMatch(pattern -> patterns.get(pattern).contains(pathMethod));
     }
 }

--- a/backend/src/main/java/botobo/core/ui/auth/PathPatterns.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathPatterns.java
@@ -3,9 +3,9 @@ package botobo.core.ui.auth;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class PathPatterns {
     private final Map<String, PathMethods> includePatterns;
@@ -19,11 +19,11 @@ public class PathPatterns {
     }
 
     public void addPathPatterns(String pathPattern, PathMethod... pathMethods) {
-        includePatterns.put(pathPattern, new PathMethods(Arrays.asList(pathMethods)));
+        includePatterns.put(pathPattern, new PathMethods(Set.of(pathMethods)));
     }
 
     public void excludePathPatterns(String pathPattern, PathMethod... pathMethods) {
-        excludePatterns.put(pathPattern, new PathMethods(Arrays.asList(pathMethods)));
+        excludePatterns.put(pathPattern, new PathMethods(Set.of(pathMethods)));
     }
 
     public boolean isExcludedPath(String uri, PathMethod pathMethod) {

--- a/backend/src/main/java/botobo/core/ui/auth/PathPatterns.java
+++ b/backend/src/main/java/botobo/core/ui/auth/PathPatterns.java
@@ -1,0 +1,38 @@
+package botobo.core.ui.auth;
+
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PathPatterns {
+    private final Map<String, PathMethods> includePatterns;
+    private final Map<String, PathMethods> excludePatterns;
+    private final PathMatcher pathMatcher;
+
+    public PathPatterns() {
+        this.includePatterns = new HashMap<>();
+        this.excludePatterns = new HashMap<>();
+        this.pathMatcher = new AntPathMatcher();
+    }
+
+    public void addPathPatterns(String pathPattern, PathMethod... pathMethods) {
+        includePatterns.put(pathPattern, new PathMethods(Arrays.asList(pathMethods)));
+    }
+
+    public void excludePathPatterns(String pathPattern, PathMethod... pathMethods) {
+        excludePatterns.put(pathPattern, new PathMethods(Arrays.asList(pathMethods)));
+    }
+
+    public boolean isExcludedPath(String uri, String httpMethod) {
+        return matchPatterns(excludePatterns, uri, httpMethod) || !matchPatterns(includePatterns, uri, httpMethod);
+    }
+
+    private boolean matchPatterns(Map<String, PathMethods> patterns, String uri, String httpMethod) {
+        return patterns.keySet().stream()
+                .filter(pattern -> pathMatcher.match(pattern, uri))
+                .anyMatch(pattern -> patterns.get(pattern).match(httpMethod));
+    }
+}

--- a/backend/src/test/java/botobo/core/domain/auth/PathMatcherInterceptorTest.java
+++ b/backend/src/test/java/botobo/core/domain/auth/PathMatcherInterceptorTest.java
@@ -1,0 +1,62 @@
+package botobo.core.domain.auth;
+
+import botobo.core.ui.auth.PathMatcherInterceptor;
+import botobo.core.ui.auth.PathMethod;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@MockitoSettings
+public class PathMatcherInterceptorTest {
+
+    @Mock
+    private HandlerInterceptor handlerInterceptor;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @InjectMocks
+    private PathMatcherInterceptor pathMatcherInterceptor;
+
+    @Test
+    @DisplayName("동일한 api와 PathMethod를 추가시키면 preHandle은 다음 인터셉터의 preHandle을 반환한다.")
+    void preHandle() throws Exception {
+        // given
+        given(httpServletRequest.getRequestURI())
+                .willReturn("/api/**");
+        given(httpServletRequest.getMethod())
+                .willReturn(HttpMethod.GET.name());
+        given(handlerInterceptor.preHandle(any(), any(), any()))
+                .willReturn(true);
+        pathMatcherInterceptor.addPathPatterns("/api/**", PathMethod.GET);
+
+        // when, then
+        assertThat(pathMatcherInterceptor.preHandle(httpServletRequest, null, null)).isEqualTo(
+                handlerInterceptor.preHandle(any(), any(), any())
+        );
+    }
+
+    @Test
+    @DisplayName("모든 api 요청에서 OPTIONS일 때를 제외시키면 preHandle에서 true를 반환한다.")
+    void preHandleWithOptions() throws Exception {
+        // given
+        given(httpServletRequest.getRequestURI())
+                .willReturn("/api/workbooks");
+        given(httpServletRequest.getMethod())
+                .willReturn(HttpMethod.OPTIONS.toString());
+        pathMatcherInterceptor.excludePathPatterns("/api/**", PathMethod.OPTIONS);
+
+        // when, then
+        assertThat(pathMatcherInterceptor.preHandle(httpServletRequest, null, null)).isTrue();
+    }
+}

--- a/backend/src/test/java/botobo/core/domain/auth/PathMethodsTest.java
+++ b/backend/src/test/java/botobo/core/domain/auth/PathMethodsTest.java
@@ -1,0 +1,43 @@
+package botobo.core.domain.auth;
+
+import botobo.core.ui.auth.PathMethod;
+import botobo.core.ui.auth.PathMethods;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PathMethodsTest {
+
+    @Test
+    @DisplayName("PathMethod가 PathMethods에 존재할 때 true, 아닐 때는 false를 반환한다.")
+    void contains() {
+        // given
+        PathMethods pathMethods = new PathMethods(Set.of(PathMethod.GET, PathMethod.POST));
+
+        // when, then
+        assertThat(pathMethods.contains(PathMethod.GET)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.POST)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.PUT)).isFalse();
+    }
+
+    @Test
+    @DisplayName("PathMethod가 ANY일 때는 어떤 method가 와도 true를 반환한다.")
+    void containsWithAny() {
+        // given
+        PathMethods pathMethods = new PathMethods(Set.of(PathMethod.ANY));
+
+        // when, then
+        assertThat(pathMethods.contains(PathMethod.GET)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.POST)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.PUT)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.HEAD)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.PATCH)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.TRACE)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.DELETE)).isTrue();
+        assertThat(pathMethods.contains(PathMethod.OPTIONS)).isTrue();
+    }
+}

--- a/backend/src/test/java/botobo/core/domain/auth/PathPatternsTest.java
+++ b/backend/src/test/java/botobo/core/domain/auth/PathPatternsTest.java
@@ -1,0 +1,43 @@
+package botobo.core.domain.auth;
+
+import botobo.core.ui.auth.PathMethod;
+import botobo.core.ui.auth.PathPatterns;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PathPatternsTest {
+
+    @Test
+    @DisplayName("제외되거나 추가되지 않은 경로는 true, 추가된 경로는 false를 반환한다.")
+    void isExcludedPath() {
+        // given
+        PathPatterns pathPatterns = new PathPatterns();
+        pathPatterns.excludePathPatterns("/api/login", PathMethod.POST);
+        pathPatterns.addPathPatterns("/api/workbooks", PathMethod.GET);
+
+        // when, then
+        assertThat(pathPatterns.isExcludedPath("/api/login", PathMethod.POST)).isTrue();
+        assertThat(pathPatterns.isExcludedPath("/api/workbooks", PathMethod.PATCH)).isTrue();
+        assertThat(pathPatterns.isExcludedPath("/api/workbooks", PathMethod.GET)).isFalse();
+    }
+
+    @Test
+    @DisplayName("추가된 경로의 PathMethod가 ANY면 항상 false를 반환한다.")
+    void isExcludedPathWithPathMethodAny() {
+        // given
+        PathPatterns pathPatterns = new PathPatterns();
+        pathPatterns.addPathPatterns("/api/**", PathMethod.ANY);
+
+        // when, then
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.POST)).isFalse();
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.GET)).isFalse();
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.PUT)).isFalse();
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.HEAD)).isFalse();
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.PATCH)).isFalse();
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.TRACE)).isFalse();
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.DELETE)).isFalse();
+        assertThat(pathPatterns.isExcludedPath("/api/**", PathMethod.OPTIONS)).isFalse();
+    }
+}


### PR DESCRIPTION
closes #297 

## 작업 내용
같은 api라도 HttpMethod에 따라 인터셉터를 타거나 안타게 해야하는 경우가 발생하여 이걸 만들었습니다.

- PathMatcherInterceptor를 만들고 데코레이터 패턴을 이용하여 경로뿐만 아니라 HttpMethod에 따라 인터셉터를 설정할 수 있도록 구현하였습니다.
- 흐름은 간단하게 이렇습니다.
1. 사용하고 싶은 인터셉터를 이용해 PathMatcherInterceptor를 만들고 경로 패턴을 설정합니다. 이때 PathMethod는 HttpMethod명을 다가지고 있는 enum인데 모든 HttpMethod를 통과하는 ANY도 추가했습니다.
 ex) addPathPatterns("/api/**", PathMethod.ANY) -> /api/**이면 HttpMethod에 상관없이 인터셉터를 통과해야함
2. PathMatcherInterceptor를 registry에 추가하여 인터셉터를 등록시킵니다.
3. 이 때 따로 registry에서 패턴 설정을 하지 않았기에 무조건 이 인터셉터를 타  PathMatcherInterceptor의 preHandle를 실행하게 됩니다.
4. request의 경로와 HttpMethod를 추출하고 등록시켜놓은 패턴과 PathMatcher를 이용해 비교합니다.
5. excludePattern를 설정했다면 설정 경로와 HttpMethod가 일치하면,  addPattern을 설정했다면 설정 경로와 HttpMethod가 일치하지 않으면 인터셉터 통과하여 api를 타도록 합니다.
6. 그게 아니라면(제외한 것도 추가하지 않은 것도 아닌 api) 진짜 찐으로 사용하고 싶은 인터셉터의 preHandle을 타도록 합니다.
 ex) AuthorizationInterceptor를 타고 토큰 검증을 한 뒤 비회원 또는 토큰 유효기간 지나면 false, 그게 아니면 true

## 주의 사항
- 다른 팀들꺼 참고 많이 했습니다ㅎㅎ;;
- 일단 시험삼아 적용해봤는데 리뷰 부탁드립니다.