### PR TITLE
Q16 - 퀴즈 페이지의 카드 슬라이드를 구현한다

### DIFF
--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -175,7 +175,7 @@ const Tooltip = styled.div<TooltipProps>`
 
 const QuizList = styled.ul<QuizListProps>`
   ${Flex()};
-  transition: transform 0.15s ease;
+  transition: transform 0.1s ease-out;
   column-gap: 1.25rem;
 `;
 


### PR DESCRIPTION
closes #325 

## 작업 내용
- 카드 슬라이드 구현
- cardSlideInfo에 슬라이드에 필요한 정보 기입
- 변화된 좌표를 계산해서 카드 넓이의 1/5 이상 이동했을 경우 카드가 넘어가도록 구현
- requestAnimationFrame을 showNextQuiz, showPrevQuiz에도 구현 - setState가 requestAnimationFrame보다 먼저 실행되는 경우가 있어 동기화가 되지 않는 문제를 해결하기 위해
## 주의 사항
- 없음
- 데스크탑에서는 슬라이드를 할 필요성을 느끼지 못해서 모바일에서만 카드 슬라이드가 가능하도록 onTouch event로 구현