### PR TITLE
Q17 - 카드 슬라이드 메시지가 모바일에서만 보이도록 수정한다

### DIFF
--- a/frontend/src/hooks/useQuiz.ts
+++ b/frontend/src/hooks/useQuiz.ts
@@ -7,8 +7,14 @@ import { quizState } from '../recoil';
 import useRouter from './useRouter';
 
 const useQuiz = () => {
-  const quizzes = useRecoilValue(quizState);
   const quizMode = useRecoilValue(quizModeState);
+  const quizzes =
+    quizMode === 'GUEST'
+      ? useRecoilValue(quizState).map((quiz, index) => ({
+          ...quiz,
+          id: index,
+        }))
+      : useRecoilValue(quizState);
   const [currentQuizIndex, setCurrentQuizIndex] = useState(0);
   const [prevQuizId, setPrevQuizId] = useState<number | null>(null);
   const { routeQuizResult, routeMain, routePrevPage } = useRouter();

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -26,6 +26,15 @@ const cardSlideInfo = {
   pointOfChange: 0,
 };
 
+const isMobile = () => {
+  const PC_DEVICE = 'win16|win32|win64|mac|macintel';
+  const platform = navigator.platform;
+
+  if (!platform) return false;
+
+  return PC_DEVICE.indexOf(platform.toLocaleLowerCase()) === -1;
+};
+
 const QuizPage = () => {
   const { quizzes, prevQuizId, currentQuizIndex, showNextQuiz, showPrevQuiz } =
     useQuiz();
@@ -120,7 +129,7 @@ const QuizPage = () => {
           )}
         </QuizWrapper>
         <PageNation>
-          {currentQuizIndex === 0 && (
+          {currentQuizIndex === 0 && isMobile() && (
             <SlideTooltip>카드를 좌우로 넘겨보세요</SlideTooltip>
           )}
           <ArrowButton onClick={showPrevQuiz}>

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -27,12 +27,12 @@ const cardSlideInfo = {
 };
 
 const isMobile = () => {
-  const PC_DEVICE = 'win16|win32|win64|mac|macintel';
+  const PC_DEVICE = ['win16', 'win32', 'win64', 'mac', 'macintel'];
   const platform = navigator.platform;
 
   if (!platform) return false;
 
-  return PC_DEVICE.indexOf(platform.toLocaleLowerCase()) === -1;
+  return !PC_DEVICE.includes(platform.toLocaleLowerCase());
 };
 
 const QuizPage = () => {
@@ -116,7 +116,7 @@ const QuizPage = () => {
               }}
             >
               {quizzes.map(({ id, question, answer, workbookName }, index) => (
-                <QuizItem key={id === 0 ? index : id} quizIndex={index}>
+                <QuizItem key={id} quizIndex={index}>
                   <Quiz
                     question={question}
                     answer={answer}

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -116,7 +116,7 @@ const QuizPage = () => {
               }}
             >
               {quizzes.map(({ id, question, answer, workbookName }, index) => (
-                <QuizItem key={id} quizIndex={index}>
+                <QuizItem key={id === 0 ? index : id} quizIndex={index}>
                   <Quiz
                     question={question}
                     answer={answer}


### PR DESCRIPTION
closes #346 

## 작업 내용
- 모바일 기기에서만 카드 슬라이드 관련 내용이 표시되도록 변경
- 비회원인 경우 id가 0이라서 key값 관련 오류가 뜨는 버그 수정
## 주의 사항
- 없음