### PR TITLE
F28 - 카드의 개행이 되지 않는 문제를 해결한다

### DIFF
--- a/frontend/src/components/CardTemplate.tsx
+++ b/frontend/src/components/CardTemplate.tsx
@@ -39,6 +39,7 @@ const CardTemplate = ({
 const Container = styled.div<ContainerStyleProps>`
   padding: 1rem;
   word-break: break-all;
+  white-space: pre-wrap;
 
   ${({ theme, isChecked, onClick }) => css`
     background-color: ${theme.color.white};


### PR DESCRIPTION
closes #351 

## 작업 내용
- 카드 템플릿에 white-space: pre-wrap; 속성을 주어 모든 카드의 개행 및 띄어쓰기가 가능하도록 변경
## 주의 사항
- 없음