### PR TITLE
U11 - 마이페이지의 정보를 수정한다

### DIFF
--- a/frontend/src/__tests__/MainPage.test.tsx
+++ b/frontend/src/__tests__/MainPage.test.tsx
@@ -10,7 +10,12 @@ describe('메인 페이지 테스트', () => {
     render(
       <RecoilRoot
         initializeState={(snap) =>
-          snap.set(userState, { userName: 'ditto', id: 1, profileUrl: '' })
+          snap.set(userState, {
+            userName: 'ditto',
+            id: 1,
+            profileUrl: '',
+            bio: '',
+          })
         }
       >
         <MainPage />

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -159,12 +159,7 @@ export const putProfileAsync = async (userInfo: UserInfoResponse) => {
 export const postProfileImageAsync = async (formData: FormData) => {
   const { data } = await request.post<Pick<UserInfoResponse, 'profileUrl'>>(
     '/users/profile',
-    formData,
-    {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    }
+    formData
   );
 
   return data;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -147,5 +147,11 @@ export const postPublicCardsAsync = async (
 };
 
 export const putNextQuizAsync = async (cardIds: number[]) => {
-  await request.put(`/cards/next-quiz`, { cardIds });
+  await request.put('/cards/next-quiz', { cardIds });
+};
+
+export const putProfileAsync = async (userInfo: UserInfoResponse) => {
+  const { id, ...params } = userInfo;
+
+  await request.put(`/users/me/${id}`, params);
 };

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -164,3 +164,7 @@ export const postProfileImageAsync = async (formData: FormData) => {
 
   return data;
 };
+
+export const postUserNameCheckAsync = async (userName: string) => {
+  await request.post('/users/name-check', userName);
+};

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -155,3 +155,17 @@ export const putProfileAsync = async (userInfo: UserInfoResponse) => {
 
   await request.put(`/users/me/${id}`, params);
 };
+
+export const postProfileImageAsync = async (formData: FormData) => {
+  const { data } = await request.post<Pick<UserInfoResponse, 'profileUrl'>>(
+    '/users/profile',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
+
+  return data;
+};

--- a/frontend/src/components/TextAreaField.tsx
+++ b/frontend/src/components/TextAreaField.tsx
@@ -69,9 +69,11 @@ const TextArea = styled.textarea<TextAreaStyleProps>`
   overflow-y: auto;
 
   ${({ theme, focusColor }) => css`
-    border-color: ${focusColor === 'gray'
-      ? theme.color.gray_8
-      : theme.color.green};
+    &:focus {
+      border-color: ${focusColor === 'gray'
+        ? theme.color.gray_8
+        : theme.color.green};
+    }
   `}
 `;
 

--- a/frontend/src/contexts/FormProvider.tsx
+++ b/frontend/src/contexts/FormProvider.tsx
@@ -12,7 +12,9 @@ interface ErrorMessages {
 interface Props {
   initialValues: Values;
   validators?: {
-    [key: string]: (value: string) => never | void;
+    [key: string]:
+      | ((value: string) => never | void)
+      | ((value: string) => Promise<never | void>);
   };
   onSubmit: (values: Values) => void;
   children: React.ReactElement | React.ReactElement[];
@@ -44,13 +46,15 @@ const FormProvider = ({
     setErrorMessages({ ...errorMessages, [key]: null });
   };
 
-  const onBlur: React.FocusEventHandler<HTMLInputElement> = ({ target }) => {
+  const onBlur: React.FocusEventHandler<HTMLInputElement> = async ({
+    target,
+  }) => {
     const key = target.name;
     const value = target.value;
     const validator = validators?.[key];
 
     try {
-      validator?.(value);
+      await validator?.(value);
       setErrorMessages({ ...errorMessages, [key]: null });
     } catch (error) {
       console.error(error);

--- a/frontend/src/contexts/FormProvider.tsx
+++ b/frontend/src/contexts/FormProvider.tsx
@@ -12,9 +12,7 @@ interface ErrorMessages {
 interface Props {
   initialValues: Values;
   validators?: {
-    [key: string]:
-      | ((value: string) => never | void)
-      | ((value: string) => Promise<never | void>);
+    [key: string]: (value: string) => never | void | Promise<never | void>;
   };
   onSubmit: (values: Values) => void;
   children: React.ReactElement | React.ReactElement[];

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -10,3 +10,4 @@ export { default as useWorkbook } from './useWorkbook';
 export { default as usePublicWorkbook } from './usePublicWorkbook';
 export { default as usePublicCard } from './usePublicCard';
 export { default as useModal } from './useModal';
+export { default as useProfile } from './useProfile';

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -1,12 +1,12 @@
 import { useRecoilState } from 'recoil';
 
-import { putProfileAsync } from './../api/';
+import { postProfileImageAsync, putProfileAsync } from './../api';
 import { userState } from './../recoil';
 import { UserInfoResponse } from './../types';
 import useSnackbar from './useSnackbar';
 
 const useProfile = () => {
-  const [userInfo] = useRecoilState(userState);
+  const [userInfo, setUserInfo] = useRecoilState(userState);
 
   const showSnackbar = useSnackbar();
 
@@ -20,7 +20,25 @@ const useProfile = () => {
     }
   };
 
-  return { userInfo, editProfile };
+  const updateProfileUrl = async (file?: File) => {
+    const formData = new FormData();
+
+    if (file) {
+      formData.append('profile', file);
+    }
+
+    try {
+      const newImage = await postProfileImageAsync(formData);
+
+      if (!userInfo) return;
+
+      setUserInfo({ ...userInfo, profileUrl: newImage.profileUrl });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return { userInfo, updateProfileUrl, editProfile };
 };
 
 export default useProfile;

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -1,0 +1,26 @@
+import { useRecoilState } from 'recoil';
+
+import { putProfileAsync } from './../api/';
+import { userState } from './../recoil';
+import { UserInfoResponse } from './../types';
+import useSnackbar from './useSnackbar';
+
+const useProfile = () => {
+  const [userInfo] = useRecoilState(userState);
+
+  const showSnackbar = useSnackbar();
+
+  const editProfile = async (userInfo: UserInfoResponse) => {
+    try {
+      await putProfileAsync(userInfo);
+      showSnackbar({ message: '프로필이 수정되었어요.' });
+    } catch (error) {
+      console.error(error);
+      showSnackbar({ message: '프로필을 수정하지 못했어요.', type: 'error' });
+    }
+  };
+
+  return { userInfo, editProfile };
+};
+
+export default useProfile;

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -21,6 +21,7 @@ const useProfile = () => {
   };
 
   const updateProfileUrl = async (file?: File) => {
+    if (!userInfo) return;
     const formData = new FormData();
 
     if (file) {
@@ -29,8 +30,6 @@ const useProfile = () => {
 
     try {
       const newImage = await postProfileImageAsync(formData);
-
-      if (!userInfo) return;
 
       setUserInfo({ ...userInfo, profileUrl: newImage.profileUrl });
     } catch (error) {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -69,14 +69,12 @@ const ProfilePage = () => {
       <Container>
         <Profile>
           <ImageContainer>
-            <ImageWrapper
-              onClick={() => setIsEditable((prevState) => !prevState)}
-            >
+            <div onClick={() => setIsEditable((prevState) => !prevState)}>
               <Avatar src={userInfo?.profileUrl ?? userSrc} />
               <EditIconWrapper>
                 <EditIcon width="1.3rem" height="1.3rem" />
               </EditIconWrapper>
-            </ImageWrapper>
+            </div>
             {isEditable && <Dimmed onClick={() => setIsEditable(false)} />}
             <ImageEditor isEditable={isEditable}>
               <ImageUploader htmlFor="image-upload">
@@ -159,9 +157,6 @@ const Profile = styled.div`
 
 const ImageContainer = styled.div`
   position: relative;
-`;
-
-const ImageWrapper = styled.div`
   cursor: pointer;
 `;
 
@@ -235,6 +230,8 @@ const ImageEditor = styled.div<ImageEditorStyleProp>`
 `;
 
 const ImageUploader = styled.label`
+  cursor: pointer;
+
   & > input {
     display: none;
   }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
-import { useRecoilState } from 'recoil';
 
 import EditIcon from '../assets/pencil.svg';
 import { Button, InputField, MainHeader, TextAreaField } from '../components';
@@ -11,7 +10,7 @@ import {
   USER_NAME_MAXIMUM_LENGTH,
 } from '../constants';
 import { FormProvider } from '../contexts';
-import { userState } from '../recoil';
+import { useProfile } from '../hooks';
 import { Flex } from '../styles';
 
 interface ImageEditorStyleProp {
@@ -33,7 +32,7 @@ const validateBio = (value: string) => {
 };
 
 const ProfilePage = () => {
-  const [userInfo] = useRecoilState(userState);
+  const { userInfo, editProfile } = useProfile();
   const [isEditable, setIsEditable] = useState(false);
 
   return (
@@ -58,15 +57,19 @@ const ProfilePage = () => {
           </ImageContainer>
           <FormProvider
             initialValues={{
-              name: userInfo?.userName ?? 'Unknown User',
+              userName: userInfo?.userName ?? 'Unknown User',
               bio: userInfo?.bio ?? '',
             }}
-            validators={{ name: validateUserName, bio: validateBio }}
-            onSubmit={({ name, bio }) => console.log(name, bio)}
+            validators={{ userName: validateUserName, bio: validateBio }}
+            onSubmit={({ userName, bio }) => {
+              if (!userInfo) return;
+
+              editProfile({ ...userInfo, userName, bio });
+            }}
           >
             <InputTitle>이름</InputTitle>
             <NameInput
-              name="name"
+              name="userName"
               focusColor="gray"
               maxLength={USER_NAME_MAXIMUM_LENGTH}
             />

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -59,7 +59,7 @@ const ProfilePage = () => {
           <FormProvider
             initialValues={{
               name: userInfo?.userName ?? 'Unknown User',
-              bio: '',
+              bio: userInfo?.bio ?? '',
             }}
             validators={{ name: validateUserName, bio: validateBio }}
             onSubmit={({ name, bio }) => console.log(name, bio)}
@@ -74,6 +74,7 @@ const ProfilePage = () => {
             <BioInput
               name="bio"
               focusColor="gray"
+              placeholder="소개글을 작성해주세요."
               maxLength={BIO_MAXIMUM_LENGTH}
             />
             <Button size="full">프로필 수정</Button>
@@ -214,10 +215,7 @@ const BioInput = styled(TextAreaField)`
   ${({ theme }) => css`
     font-size: ${theme.fontSize.default};
     border-radius: ${theme.borderRadius.square};
-
-    &:focus {
-      border: 1px solid ${theme.color.gray_8};
-    }
+    border: 1px solid ${theme.color.gray_4};
   `}
 `;
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
 
+import { postUserNameCheckAsync } from '../api';
 import EditIcon from '../assets/pencil.svg';
 import { Button, InputField, MainHeader, TextAreaField } from '../components';
 import {
@@ -27,9 +28,14 @@ const validateFileSize = (size: number) => {
   }
 };
 
-const validateUserName = (value: string) => {
+const validateUserName = async (value: string) => {
+  await postUserNameCheckAsync(value);
+
   if (value.length > USER_NAME_MAXIMUM_LENGTH) {
     throw new Error(`닉네임은 ${USER_NAME_MAXIMUM_LENGTH}자 이하여야 합니다.`);
+  }
+  if (/\s/.test(value)) {
+    throw new Error('닉네임에 공백은 허용할 수 없습니다.');
   }
 };
 
@@ -104,7 +110,13 @@ const ProfilePage = () => {
               userName: userInfo?.userName ?? 'Unknown User',
               bio: userInfo?.bio ?? '',
             }}
-            validators={{ userName: validateUserName, bio: validateBio }}
+            validators={{
+              userName: async (value) => {
+                if (value === userInfo?.userName) return;
+                await validateUserName(value);
+              },
+              bio: validateBio,
+            }}
             onSubmit={({ userName, bio }) => {
               if (!userInfo) return;
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -34,6 +34,7 @@ const validateUserName = async (value: string) => {
   if (value.length > USER_NAME_MAXIMUM_LENGTH) {
     throw new Error(`닉네임은 ${USER_NAME_MAXIMUM_LENGTH}자 이하여야 합니다.`);
   }
+
   if (/\s/.test(value)) {
     throw new Error('닉네임에 공백은 허용할 수 없습니다.');
   }
@@ -97,8 +98,8 @@ const ProfilePage = () => {
                 type="button"
                 role="image-delete-button"
                 onClick={() => {
-                  updateProfileUrl();
                   setIsEditable(false);
+                  updateProfileUrl();
                 }}
               >
                 이미지 제거
@@ -113,6 +114,7 @@ const ProfilePage = () => {
             validators={{
               userName: async (value) => {
                 if (value === userInfo?.userName) return;
+
                 await validateUserName(value);
               },
               bio: validateBio,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,4 +53,5 @@ export interface UserInfoResponse {
   id: number;
   userName: string;
   profileUrl: string;
+  bio: string;
 }


### PR DESCRIPTION
closes #338 

## 작업 내용
- 프로필 이미지 업로드
- 유저 정보 수정
## 주의 사항
- 이미지 업로드 기능이 제대로 동작하는지 확인하려면, baseURL을 dev 버전으로 바꿔서 확인해봐야 합니다. AWS 인스턴스의 특정 권한(IAM)이 local 서버에는 뚫려있지 않아 번거롭겠지만 이렇게 확인할 수밖에 없네요 ㅠ
- 유저 정보 수정은 현재 백엔드에서 머지가 안된 상태라 기존 카드 정보 수정 로직과 동일하게 가져갔습니다.
- 이미지가 업로드 되었을 때, 이미지 바뀌는 걸로 충분하다고 생각해 스낵바는 따로 띄우지 않고 유저 정보가 수정되었을 때만 띄우게 해놓았습니다. 디토의 생각은 어떤지 궁금하네요 ㅎㅎ