### PR TITLE
U13 - User save할 때 회원명이 중복 되어있을 경우 뒤에 숫자를 붙여주고 save를 한다.

### DIFF
--- a/backend/src/main/java/botobo/core/application/AuthService.java
+++ b/backend/src/main/java/botobo/core/application/AuthService.java
@@ -41,8 +41,16 @@ public class AuthService {
         if (user.isPresent()) {
             return TokenResponse.of(jwtTokenProvider.createToken(user.get().getId()));
         }
+        validateUserName(userInfo);
         User savedUser = userRepository.save(userInfo);
         return TokenResponse.of(jwtTokenProvider.createToken(savedUser.getId()));
+    }
+
+    private void validateUserName(User userInfo) {
+        String originalName = userInfo.getUserName();
+        while (userRepository.existsByUserName(userInfo.getUserName())) {
+            userInfo.changeUserName(originalName);
+        }
     }
 
     public AppUser findAppUserByToken(String credentials) {

--- a/backend/src/main/java/botobo/core/domain/user/User.java
+++ b/backend/src/main/java/botobo/core/domain/user/User.java
@@ -75,4 +75,13 @@ public class User extends BaseEntity {
     public boolean isUser() {
         return role.isUser();
     }
+
+    public void changeUserName(String originalName) {
+        String suffix = userName.replace(originalName, "");
+        int suffixNumber = 0;
+        if (!suffix.isEmpty()) {
+            suffixNumber = Integer.parseInt(suffix);
+        }
+        this.userName = originalName + (suffixNumber + 1);
+    }
 }

--- a/backend/src/main/java/botobo/core/domain/user/UserRepository.java
+++ b/backend/src/main/java/botobo/core/domain/user/UserRepository.java
@@ -8,4 +8,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByIdAndRole(Long id, Role role);
 
     Optional<User> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+
+    boolean existsByUserName(String userName);
 }

--- a/backend/src/test/java/botobo/core/acceptance/user/UserAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/acceptance/user/UserAcceptanceTest.java
@@ -8,6 +8,7 @@ import botobo.core.dto.auth.UserInfoResponse;
 import botobo.core.dto.user.ProfileResponse;
 import botobo.core.dto.user.UserResponse;
 import botobo.core.exception.common.ErrorResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,20 +25,23 @@ public class UserAcceptanceTest extends DomainAcceptanceTest {
     @Value("${aws.cloudfront.url-format}")
     private String cloudFrontUrlFormat;
 
-    @Test
-    @DisplayName("로그인 한 유저의 정보를 가져온다. - 성공")
-    void findByUserOfMine() {
-        // given
-        UserInfoResponse userInfoResponse = GithubUserInfoResponse.builder()
+    @BeforeEach
+    void setFixture() {
+        userInfo = GithubUserInfoResponse.builder()
                 .userName("socialUser")
                 .socialId("2")
                 .profileUrl("social.io")
                 .build();
 
-        //when
+    }
+
+    @Test
+    @DisplayName("로그인 한 유저의 정보를 가져온다. - 성공")
+    void findByUserOfMine() {
+        // given, when
         final HttpResponse response = request()
                 .get("/api/users/me")
-                .auth(소셜_로그인되어_있음(userInfoResponse, SocialType.GITHUB))
+                .auth(소셜_로그인되어_있음(userInfo, SocialType.GITHUB))
                 .build();
 
         UserResponse userResponse = response.convertBody(UserResponse.class);
@@ -66,18 +70,13 @@ public class UserAcceptanceTest extends DomainAcceptanceTest {
     @DisplayName("프로필 이미지를 수정한다. - 성공, multipartFile이 비어있는 경우 디폴트 유저 이미지로 대체")
     void updateWhenDefaultProfile() {
         //given
-        UserInfoResponse userInfoResponse = GithubUserInfoResponse.builder()
-                .userName("socialUser")
-                .socialId("2")
-                .profileUrl("social.io")
-                .build();
         MockMultipartFile mockMultipartFile = null;
         String defaultUserImageUrl = String.format(cloudFrontUrlFormat, userDefaultImage);
 
         //when
         final HttpResponse response = request()
                 .post("/api/users/profile", mockMultipartFile)
-                .auth(소셜_로그인되어_있음(userInfoResponse, SocialType.GITHUB))
+                .auth(소셜_로그인되어_있음(userInfo, SocialType.GITHUB))
                 .build();
 
         ProfileResponse profileResponse = response.convertBody(ProfileResponse.class);
@@ -85,5 +84,89 @@ public class UserAcceptanceTest extends DomainAcceptanceTest {
         //then
         assertThat(profileResponse.getProfileUrl()).isNotNull();
         assertThat(profileResponse.getProfileUrl()).isEqualTo(defaultUserImageUrl);
+    }
+
+    @Test
+    @DisplayName("로그인 한 유저의 정보를 가져온다. - 성공, 다른 유저와 회원명이 같을 경우 뒤에 숫자가 추가된다. (숫자는 차례대로 1씩 증가)")
+    void findByUserOfMineWithSameUserName() {
+        // given
+        소셜_로그인_요청(userInfo, SocialType.GITHUB);
+        UserInfoResponse otherUserInfo = GithubUserInfoResponse.builder()
+                .userName("socialUser")
+                .socialId("3")
+                .profileUrl("github.io")
+                .build();
+        소셜_로그인_요청(otherUserInfo, SocialType.GITHUB);
+
+        // when
+        final HttpResponse response = request()
+                .get("/api/users/me")
+                .auth(소셜_로그인되어_있음(otherUserInfo, SocialType.GITHUB))
+                .build();
+
+        UserResponse userResponse = response.convertBody(UserResponse.class);
+
+        // then
+        assertThat(userResponse.getId()).isNotNull();
+        assertThat(userResponse.getUserName()).isEqualTo("socialUser1");
+        assertThat(userResponse.getProfileUrl()).isEqualTo("github.io");
+    }
+
+    @Test
+    @DisplayName("로그인 한 유저의 회원명을 비교한다. - 성공, 다른 유저와 회원명이 같을 경우 뒤에 숫자가 추가된다. (동일 회원명이 2개일 경우)")
+    void findByUserOfMineWithTwoSameUserName() {
+        // given
+        소셜_로그인_요청(userInfo, SocialType.GITHUB);
+        UserInfoResponse otherUserInfo1 = GithubUserInfoResponse.builder()
+                .userName("socialUser")
+                .socialId("3")
+                .profileUrl("github.io")
+                .build();
+        소셜_로그인_요청(otherUserInfo1, SocialType.GITHUB);
+        UserInfoResponse otherUserInfo2 = GithubUserInfoResponse.builder()
+                .userName("socialUser")
+                .socialId("4")
+                .profileUrl("github.io")
+                .build();
+
+
+        // when
+        final HttpResponse response = request()
+                .get("/api/users/me")
+                .auth(소셜_로그인되어_있음(otherUserInfo2, SocialType.GITHUB))
+                .build();
+
+        UserResponse userResponse = response.convertBody(UserResponse.class);
+
+        // then
+        assertThat(userResponse.getId()).isNotNull();
+        assertThat(userResponse.getUserName()).isEqualTo("socialUser2");
+        assertThat(userResponse.getProfileUrl()).isEqualTo("github.io");
+    }
+
+    @Test
+    @DisplayName("로그인 한 유저의 회원명을 비교한다. - 성공, 다른 유저와 회원명이 다른 경우")
+    void findByUserOfMineWithDifferentUserName() {
+        // given
+        소셜_로그인_요청(userInfo, SocialType.GITHUB);
+
+        UserInfoResponse otherUserInfo = GithubUserInfoResponse.builder()
+                .userName("oz")
+                .socialId("3")
+                .profileUrl("github.io")
+                .build();
+
+        // when
+        final HttpResponse response = request()
+                .get("/api/users/me")
+                .auth(소셜_로그인되어_있음(otherUserInfo, SocialType.GITHUB))
+                .build();
+
+        UserResponse userResponse = response.convertBody(UserResponse.class);
+
+        // then
+        assertThat(userResponse.getId()).isNotNull();
+        assertThat(userResponse.getUserName()).isEqualTo("oz");
+        assertThat(userResponse.getProfileUrl()).isEqualTo("github.io");
     }
 }

--- a/backend/src/test/java/botobo/core/domain/user/UserTest.java
+++ b/backend/src/test/java/botobo/core/domain/user/UserTest.java
@@ -2,7 +2,10 @@ package botobo.core.domain.user;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class UserTest {
@@ -17,5 +20,38 @@ public class UserTest {
                 .profileUrl("profile.io")
                 .build()
         ).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"oz", "oz1", "oz2"})
+    @DisplayName("현재 회원명과 같은 회원명이 인자로 들어오면 뒤에 숫자 1을 추가한다. - 성공")
+    void changeUserName(String name) {
+        // given
+        User user = User.builder()
+                .userName(name)
+                .build();
+
+        // when
+        user.changeUserName(name);
+
+        // then
+        assertThat(user.getUserName()).isEqualTo(name + 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"oz1", "oz702", "oz1203"})
+    @DisplayName("현재 회원명과 앞부분이 같은 회원명이 인자로 들어오면 뒤에 숫자 1을 더한 값을 추가한다. - 성공")
+    void changeUserNameWithSamePrefix(String name) {
+        // given
+        User user = User.builder()
+                .userName(name)
+                .build();
+        String suffix = name.replace("oz", "");
+
+        // when
+        user.changeUserName("oz");
+
+        // then
+        assertThat(user.getUserName()).isEqualTo("oz" + (Integer.parseInt(suffix) + 1));
     }
 }


### PR DESCRIPTION
closes #344 

## 작업 내용
- 소셜로그인을 이용하여 User 엔티티를 save할 때 회원명이 중복일 시 뒤에 숫자 1을 붙여줍니다.
- 만약 숫자 1을 붙였는데 똑같은 회원명이 있다면 숫자를 1 증가시켜 붙여줍니다.

## 주의 사항
- 코드가 좀 허접한거 같은데 리뷰 부탁드립니다ㅜ
- 극단적인 상황 (oz부터 oz1000000000까지 있는 상태) 에서 oz로 로그인을 하였을 때 반복문을 저 숫자만큼 돌아야하는 이슈가 있습니다.
- 이런 경우는 중복 회원명 전략을 바꾸는 방향으로 가야될 것 같습니다ㅎㅎ;