### PR TITLE
U15 - 프로필 페이지를 스크롤 가능하게 변경한다

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -162,7 +162,6 @@ const Container = styled.div`
   ${({ theme }) =>
     css`
       padding: ${theme.pageSize.padding};
-      height: ${theme.pageSize.height};
     `}
 `;
 


### PR DESCRIPTION
closes #380 

## 작업 내용
- 프로필의 height가 고정되어 있어 height가 작은 환경일 경우 위, 아래가 잘려 보였습니다! 프로필 페이지를 비율에 맞게 조절할까 생각했지만 마진은 그대로 유지하고 스크롤 가능하게 만들어주는 게 좋을 것 같아 관련 처리를 해주었습니다~
## 주의 사항