### PR TITLE
F33 - 비회원도 검색이 가능하도록 수정하기

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -94,17 +94,17 @@ const routes = [
   {
     path: ROUTE.PUBLIC_SEARCH.PATH,
     component: <PublicSearchPage />,
-    isPublic: false,
+    isPublic: true,
   },
   {
     path: ROUTE.PUBLIC_SEARCH_RESULT.PATH,
     component: <PublicSearchResultPage />,
-    isPublic: false,
+    isPublic: true,
   },
   {
     path: ROUTE.PUBLIC_CARDS.PATH,
     component: <PublicCardsPage />,
-    isPublic: false,
+    isPublic: true,
   },
   {
     path: `(${ROUTE.GITHUB_CALLBACK.PATH}|${ROUTE.GOOGLE_CALLBACK.PATH})`,

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -20,7 +20,7 @@ import {
   WorkbookResponse,
 } from '../types';
 import { ValueOf } from '../types/utils';
-import { getLocalStorage } from '../utils';
+import { getLocalStorage, removeLocalStorage, setLocalStorage } from '../utils';
 
 interface PostCardAsync {
   question: string;
@@ -53,7 +53,9 @@ const request = axios.create({
 
 const token = getLocalStorage(STORAGE_KEY.TOKEN);
 
-request.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+request.defaults.headers.common['Authorization'] = token
+  ? `Bearer ${token}`
+  : '';
 
 export const getAccessTokenAsync = async (
   socialType: AuthType,
@@ -63,9 +65,17 @@ export const getAccessTokenAsync = async (
     data: { accessToken },
   } = await request.post<AccessTokenResponse>(`/login/${socialType}`, { code });
 
+  setLocalStorage(STORAGE_KEY.TOKEN, accessToken);
+
   request.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
 
   return accessToken;
+};
+
+export const postLogoutAsync = async () => {
+  removeLocalStorage(STORAGE_KEY.TOKEN);
+
+  request.defaults.headers.common['Authorization'] = '';
 };
 
 export const getWorkbooksAsync = async () => {

--- a/frontend/src/contexts/ModalProvider.tsx
+++ b/frontend/src/contexts/ModalProvider.tsx
@@ -178,7 +178,7 @@ const Dimmed = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 2;
+  z-index: 3;
 
   ${({ theme }) => css`
     background-color: ${`${theme.color.black}80`};
@@ -209,7 +209,7 @@ const Header = styled.div<HeaderStyleProps>`
 
 const Container = styled.div<Pick<BottomSheetProps, 'type' | 'isOpened'>>`
   position: fixed;
-  z-index: 3;
+  z-index: 4;
   padding: 1rem;
 
   transition: visibility 0.2s;

--- a/frontend/src/hooks/usePublicCard.ts
+++ b/frontend/src/hooks/usePublicCard.ts
@@ -174,6 +174,7 @@ const usePublicCard = () => {
     takeCardsToMyWorkbook,
     isLoading,
     toggleHeart,
+    showSnackbar,
   };
 };
 

--- a/frontend/src/pages/LogoutPage.tsx
+++ b/frontend/src/pages/LogoutPage.tsx
@@ -1,20 +1,25 @@
-import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 
-import { STORAGE_KEY } from '../constants';
+import { postLogoutAsync } from '../api';
 import { useRouter } from '../hooks';
 import { userState } from '../recoil';
-import { removeLocalStorage } from '../utils';
 
 const LogoutPage = () => {
   const { routeMain } = useRouter();
   const setUserInfo = useSetRecoilState(userState);
 
-  useEffect(() => {
-    removeLocalStorage(STORAGE_KEY.TOKEN);
-    setUserInfo(null);
-    routeMain();
-  }, []);
+  const logout = async () => {
+    try {
+      await postLogoutAsync();
+      setUserInfo(null);
+      routeMain();
+    } catch (error) {
+      //TODO: 에러 바운더리로 보내기
+      console.error(error);
+    }
+  };
+
+  logout();
 
   return null;
 };

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -3,7 +3,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { getAccessTokenAsync } from '../api';
 import { ROUTE, STORAGE_KEY } from '../constants';
 import { AuthType } from '../types';
-import { getSessionStorage, setLocalStorage } from '../utils';
+import { getSessionStorage } from '../utils';
 
 const OAuthCallbackPage = () => {
   const { search } = useLocation();
@@ -15,9 +15,7 @@ const OAuthCallbackPage = () => {
 
   const login = async () => {
     try {
-      const accessToken = await getAccessTokenAsync(type, code);
-
-      setLocalStorage(STORAGE_KEY.TOKEN, accessToken);
+      await getAccessTokenAsync(type, code);
 
       //TODO: 훅으로 빼는 방법 고민하기
       history.push(

--- a/frontend/src/pages/PublicCardsPage.tsx
+++ b/frontend/src/pages/PublicCardsPage.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { getQuizzesAsync } from '../api';
 import EmptyHeartIcon from '../assets/heart-regular.svg';
@@ -16,7 +16,7 @@ import {
 } from '../components';
 import { QUIZ_MODE, ROUTE, theme } from '../constants';
 import { useModal, usePublicCard, useRouter, useWorkbook } from '../hooks';
-import { quizModeState, quizState } from '../recoil';
+import { quizModeState, quizState, userState } from '../recoil';
 import { Flex } from '../styles';
 import { debounce } from '../utils';
 import PublicCardsLoadable from './PublicCardsLoadable';
@@ -24,6 +24,8 @@ import PublicCardsLoadable from './PublicCardsLoadable';
 const PublicCardsPage = () => {
   const setQuiz = useSetRecoilState(quizState);
   const setQuizMode = useSetRecoilState(quizModeState);
+  const isLogin = useRecoilValue(userState) ? true : false;
+
   const { workbooks } = useWorkbook();
   const {
     workbookId,
@@ -40,6 +42,7 @@ const PublicCardsPage = () => {
     takeCardsToMyWorkbook,
     isLoading,
     toggleHeart,
+    showSnackbar,
   } = usePublicCard();
 
   const { openModal, closeModal } = useModal();
@@ -48,6 +51,12 @@ const PublicCardsPage = () => {
   const { heart, heartCount, serverHeart } = heartInfo;
 
   const onClickHeart = () => {
+    if (!isLogin) {
+      showSnackbar({ message: '로그인이 필요해요.' });
+
+      return;
+    }
+
     debounce(() => {
       if (serverHeart === !heart) return;
 
@@ -144,6 +153,12 @@ const PublicCardsPage = () => {
             disabled={checkedCardCount === 0}
             onClick={() => {
               if (checkedCardCount === 0) return;
+
+              if (!isLogin) {
+                showSnackbar({ message: '로그인이 필요해요.' });
+
+                return;
+              }
 
               openModal({
                 content: (

--- a/frontend/src/pages/WorkbookEditPage.tsx
+++ b/frontend/src/pages/WorkbookEditPage.tsx
@@ -30,7 +30,7 @@ const WorkbookEditPage = () => {
 
   return (
     <>
-      <MainHeader />
+      <MainHeader shadow={false} />
       <FormProvider
         initialValues={{ name: editedWorkbook.name }}
         validators={{ name: validateWorkbookName }}


### PR DESCRIPTION
closes #385 

## 작업 내용
- 비회원 검색 기능 추가
- 페이지 z-index 문제 해결(문제집 수정, 공유 카드 페이지의 문제집 가져가기)
- 비회원인 경우에도 Bearer이 들어가는 버그 해결
## 주의 사항
- 로그인, 로그아웃을 할 때 페이지 단에서 토큰을 로컬스토리지에 set하는 것이 아닌 api 메서드 자체에서 set하고 clear하도록 변경하였음
- 로그아웃 api는 현재 존재하지 않지만, 다음 스프린트 때 추가될 예정으로 내부를 미리 구현해놓았음