### PR TITLE
B46 - sonarqube 커버리지 기준을 설정한다 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -98,9 +98,39 @@ jacoco {
 
 jacocoTestReport {
     reports {
-        html.enabled false
+        html.enabled true
         xml.enabled true
         csv.enabled false
+    }
+//    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+
+            excludes = [
+                    'botobo.core.infrastructure.**',
+                    'botobo.core.exception.**',
+                    'botobo.core.dto.**',
+                    'botobo.core.DataLoader',
+                    'botobo.core.BotoboApplication'
+            ]
+        }
     }
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -155,6 +155,11 @@ sonarqube {
         property "sonar.junit.reportsPath", "$buildDir/test-reports"
         property "sonar.java.coveragePlugin", "jacoco"
         property "sonar.coverage.jacoco.reportPaths", "$buildDir/jacoco/jacoco.exec"
+        property "sonar.exclusions", "botobo/core/infrastructure/**, " +
+                "botobo/core/exception/**, " +
+                "botobo/core/dto/**, " +
+                "botobo/core/DataLoader.java, " +
+                "botobo/core/BotoboApplication.java"
     }
 }
 

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/backend/src/test/java/botobo/core/application/WorkbookServiceTest.java
+++ b/backend/src/test/java/botobo/core/application/WorkbookServiceTest.java
@@ -193,6 +193,40 @@ class WorkbookServiceTest {
     }
 
     @Test
+    @DisplayName("비회원 공유 문제집 상세보기 - 성공")
+    void findPublicWorkbookByIdWithAnonymousAppUser() {
+        // given
+        Workbook workbook = Workbook.builder()
+                .id(1L)
+                .name("피케이의 공유 문제집")
+                .cards(new Cards(List.of(
+                                Card.builder()
+                                        .id(1L)
+                                        .question("question")
+                                        .answer("answer")
+                                        .build())
+                        )
+                )
+                .opened(true)
+                .build();
+        Long userId = normalUser.getId();
+        Heart heart = Heart.builder().workbook(workbook).userId(userId).build();
+        workbook.toggleHeart(heart);
+
+        given(workbookRepository.findByIdAndOrderCardByNew(anyLong())).willReturn(Optional.ofNullable(workbook));
+
+        // when
+        WorkbookCardResponse response = workbookService.findPublicWorkbookById(1L, AppUser.anonymous());
+
+        // then
+        assertThat(response.getHeartCount()).isEqualTo(1);
+        assertThat(response.getHeart()).isFalse();
+
+        then(workbookRepository).should(times(1))
+                .findByIdAndOrderCardByNew(anyLong());
+    }
+
+    @Test
     @DisplayName("공유 문제집 상세보기 - 실패, 문제집이 공유 문제집이 아닌 경우")
     void findPublicWorkbookWithFalseOpenedById() {
         // given

--- a/backend/src/test/java/botobo/core/domain/user/UserTest.java
+++ b/backend/src/test/java/botobo/core/domain/user/UserTest.java
@@ -1,8 +1,12 @@
 package botobo.core.domain.user;
 
+import botobo.core.domain.workbook.Workbook;
 import botobo.core.exception.user.ProfileUpdateNotAllowedException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -32,7 +36,24 @@ public class UserTest {
                 .userName("user")
                 .profileUrl("profile.io")
                 .build();
-        assertThat(user.getBio()).isEqualTo("");
+        assertThat(user.getBio()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("문제집을 포함한 User 객체 생성 - 성공")
+    void createWithWorkbook() {
+        // given
+        Workbook workbook = Workbook.builder()
+                .name("workbook")
+                .build();
+        assertThatCode(() -> User.builder()
+                .id(1L)
+                .socialId("1")
+                .userName("user")
+                .profileUrl("profile.io")
+                .workbooks(Collections.singletonList(workbook))
+                .build()
+        ).doesNotThrowAnyException();
     }
 
     @Test
@@ -46,6 +67,34 @@ public class UserTest {
                 .bio("백엔드 개발자 유저입니다.")
                 .build();
         assertThat(user.getBio()).isEqualTo("백엔드 개발자 유저입니다.");
+    }
+
+    @Test
+    @DisplayName("다른 유저와 이름 비교 - 성공")
+    void isSameName() {
+        User user = User.builder()
+                .id(1L)
+                .socialId("1")
+                .userName("user")
+                .profileUrl("profile.io")
+                .bio("백엔드 개발자 유저입니다.")
+                .build();
+        User anotherUser = User.builder()
+                .id(1L)
+                .socialId("1")
+                .userName("user")
+                .profileUrl("profile.io")
+                .bio("백엔드 개발자 유저입니다.")
+                .build();
+        User pk = User.builder()
+                .id(1L)
+                .socialId("1")
+                .userName("pk")
+                .profileUrl("profile.io")
+                .bio("백엔드 개발자 유저입니다.")
+                .build();
+        assertThat(user.isSameName(anotherUser)).isTrue();
+        assertThat(user.isSameName(pk)).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/botobo/core/domain/workbook/WorkbookTest.java
+++ b/backend/src/test/java/botobo/core/domain/workbook/WorkbookTest.java
@@ -152,6 +152,36 @@ class WorkbookTest {
         assertThat(workbook.author()).isEqualTo("존재하지 않는 유저");
     }
 
+    @Test
+    @DisplayName("createBy를 하면 문제집의 author가 주어진 user로 바뀐다 - 성공")
+    void createByWithNewAuthor() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .socialId("1")
+                .userName("oz")
+                .profileUrl("github.io")
+                .role(Role.USER)
+                .build();
+        User newUser = User.builder()
+                .id(1L)
+                .socialId("1")
+                .userName("pk")
+                .profileUrl("github.io")
+                .role(Role.USER)
+                .build();
+        Workbook workbook = Workbook.builder()
+                .name("단계별 자바 문제집")
+                .user(user)
+                .build();
+
+        // when
+        workbook.createBy(newUser);
+
+        // then
+        assertThat(workbook.author()).isEqualTo(newUser.getUserName());
+    }
+
     @ValueSource(strings = {"java", "Java", "JAVA", "JaVa"})
     @ParameterizedTest
     @DisplayName("문제집의 이름에 해당 단어가 포함되어 있는지 검사한다.(영어는 소문자로 변환하여 검사)")

--- a/backend/src/test/java/botobo/core/ui/search/SearchKeywordTest.java
+++ b/backend/src/test/java/botobo/core/ui/search/SearchKeywordTest.java
@@ -69,6 +69,15 @@ class SearchKeywordTest {
     }
 
     @Test
+    @DisplayName("SearchKeyword 객체 생성 - 실패, 짧은 문자열")
+    void createWithShortString() {
+        // when, then
+        assertThatThrownBy(() -> SearchKeyword.of(""))
+                .isInstanceOf(SearchKeywordCreationFailureException.class)
+                .hasMessageContaining("검색어는 1자 이상이어야 합니다.");
+    }
+
+    @Test
     @DisplayName("SearchKeyword 객체 생성 - 실패, 금지어 포함")
     void createWithForbiddenString() {
         // when, then


### PR DESCRIPTION
closes #371 

## 작업 내용
build.gradle 에 jacoco 테스트 커버리지 확인 과정을 추가했습니다.
`jacocoTestCoverageVerification` 부분을 확인하시면 됩니다! (발표 준비 먼저 하다가 wiki에 관련 내용 추가할게요)

간단하게 두 개의 limit 이 있는데, 하나는 분기점 커버리지, 그리고 하나는 코드 라인 커버리지 입니다.
둘 다 90% 이상인지 확인하도록 되어 있습니다.

이 확인 과정을 test 실행될 때마다 하면 참 좋긴한데, 일단 주석처리 해놓았습니다.
현재 누락된 테스트를 몇 개 추가하여 90%를 넘기긴 하지만, 데모 전에 새로 머지하는 기능이 테스트 커버리지 90% 미달이 되어 통과하지 못하면 시간상 불편하니까요.

## 주의 사항
lombok.config 라는 파일이 새로 생겼는데, 이 설정을 통해 jacoco 가 커버리지 검증할 때 lombok 으로 생성되는 코드는 무시합니다.
Lombok 관련 부분에 `@Generated` 어노테이션을 추가로 달아서 jacoco 가 바로 넘기는 방식이라네요!