### PR TITLE
F36 - 하트 위치 변경 및 태그 검색 기능 추가

### DIFF
--- a/frontend/src/components/Hashtag.tsx
+++ b/frontend/src/components/Hashtag.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import React, { useState } from 'react';
 
 import DeleteIcon from '../assets/cross-mark.svg';
+import { useSnackbar } from '../hooks';
 import { Flex } from '../styles';
 import { TagResponse } from '../types';
 
@@ -12,9 +13,11 @@ interface Props {
 }
 
 const MAX_HASHTAG_COUNT = 5;
+const MAX_HASHTAG_LENGTH = 20;
 
 const Hashtag = ({ hashtags, setHashtags }: Props) => {
   const [value, setValue] = useState('');
+  const showSnackbar = useSnackbar();
 
   const submitHashtag: React.KeyboardEventHandler<HTMLInputElement> = (
     event
@@ -22,6 +25,13 @@ const Hashtag = ({ hashtags, setHashtags }: Props) => {
     if (event.key !== 'Enter' || value === '') return;
 
     event.preventDefault();
+
+    if (value.length > MAX_HASHTAG_LENGTH) {
+      showSnackbar({ message: '해시태그는 20자 이하로 입력해주세요.' });
+
+      return;
+    }
+
     setValue('');
 
     if (hashtags.map(({ name }) => name).includes(value)) return;

--- a/frontend/src/components/Hashtag.tsx
+++ b/frontend/src/components/Hashtag.tsx
@@ -27,7 +27,7 @@ const Hashtag = ({ hashtags, setHashtags }: Props) => {
     event.preventDefault();
 
     if (value.length > MAX_HASHTAG_LENGTH) {
-      showSnackbar({ message: '해시태그는 20자 이하로 입력해주세요.' });
+      showSnackbar({ message: '해시태그는 20자를 넘길 수 없어요.' });
 
       return;
     }

--- a/frontend/src/components/PublicCardsSelectBox.tsx
+++ b/frontend/src/components/PublicCardsSelectBox.tsx
@@ -41,7 +41,7 @@ const PublicCardsSelectBox = ({
         )}
         <CheckBoxWrapper>
           <Checkbox
-            labelText={`[공유] ${publicWorkbookName}로 추가하기`}
+            labelText={`[공유] ${publicWorkbookName}(으)로 추가하기`}
             name="defaultAdd"
             checked={isDefaultSelected}
             onChange={({ target }) => setIsDefaultSelected(target.checked)}

--- a/frontend/src/hooks/useRouter.ts
+++ b/frontend/src/hooks/useRouter.ts
@@ -17,6 +17,7 @@ interface PublicSearchQuery {
   keyword?: string;
   size?: number;
   start?: number;
+  method?: 'push' | 'replace';
 }
 
 const useRouter = () => {
@@ -45,8 +46,9 @@ const useRouter = () => {
     type = 'name',
     keyword = '',
     size = 20,
+    method = 'replace',
   }: PublicSearchQuery = {}) =>
-    history.replace({
+    history[method]({
       pathname: ROUTE.PUBLIC_SEARCH.PATH,
       search: `?type=${type}&keyword=${keyword}&size=${size}`,
     });

--- a/frontend/src/pages/CardsPage.tsx
+++ b/frontend/src/pages/CardsPage.tsx
@@ -110,6 +110,7 @@ const Container = styled.div`
 `;
 
 const WorkbookName = styled.h2`
+  word-break: break-all;
   margin-bottom: 1rem;
 `;
 

--- a/frontend/src/pages/PublicCardsPage.tsx
+++ b/frontend/src/pages/PublicCardsPage.tsx
@@ -45,6 +45,8 @@ const PublicCardsPage = () => {
     showSnackbar,
   } = usePublicCard();
 
+  const { routePublicSearchQuery } = useRouter();
+
   const { openModal, closeModal } = useModal();
   const { routeQuiz } = useRouter();
 
@@ -97,33 +99,42 @@ const PublicCardsPage = () => {
         }
       />
       <Container>
+        <Heart>
+          <button type="button" onClick={onClickHeart}>
+            {heart ? (
+              <FillHeartIcon
+                width="1.5rem"
+                height="1.5rem"
+                fill={theme.color.red}
+              />
+            ) : (
+              <EmptyHeartIcon width="1.5rem" height="1.5rem" />
+            )}
+          </button>
+          <div>{heartCount}</div>
+        </Heart>
         <TopContent>
           <WorkbookName>{workbookName}</WorkbookName>
           <CardCount>{cardCount}개의 카드</CardCount>
-          <TagList>
+          <ul>
             {tags.map(({ id, name }) => (
-              <li key={id}>
-                <Tag>
+              <TagWrapper key={id}>
+                <Tag
+                  type="button"
+                  onClick={() =>
+                    routePublicSearchQuery({
+                      keyword: name,
+                      type: 'tag',
+                      method: 'push',
+                    })
+                  }
+                >
                   <span>#</span>
                   {name}
                 </Tag>
-              </li>
+              </TagWrapper>
             ))}
-          </TagList>
-          <Heart>
-            <button type="button" onClick={onClickHeart}>
-              {heart ? (
-                <FillHeartIcon
-                  width="1.5rem"
-                  height="1.5rem"
-                  fill={theme.color.red}
-                />
-              ) : (
-                <EmptyHeartIcon width="1.5rem" height="1.5rem" />
-              )}
-            </button>
-            <div>{heartCount}</div>
-          </Heart>
+          </ul>
         </TopContent>
         <ul>
           {cards.map(({ id, question, answer, isChecked }) => (
@@ -192,6 +203,7 @@ const StyledButton = styled(Button)`
 `;
 
 const Container = styled.div`
+  position: relative;
   margin-bottom: 3rem;
 
   ${({ theme }) =>
@@ -201,8 +213,15 @@ const Container = styled.div`
     `}
 `;
 
+const Heart = styled.div`
+  ${Flex({ direction: 'column', items: 'center' })};
+  position: absolute;
+  top: 2rem;
+  right: 1.25rem;
+`;
+
 const TopContent = styled.div`
-  position: relative;
+  width: calc(100% - 2rem);
 `;
 
 const WorkbookName = styled.h2`
@@ -217,20 +236,14 @@ const CardCount = styled.div`
   `};
 `;
 
-const Heart = styled.div`
-  ${Flex({ direction: 'column', items: 'center' })};
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: 0.5rem;
-`;
-
-const TagList = styled.ul`
-  ${Flex({ items: 'center' })};
+const TagWrapper = styled.li`
+  display: inline-block;
+  word-break: break-all;
 `;
 
 const Tag = styled.button`
   margin-right: 0.5rem;
+  text-align: left;
 
   ${({ theme }) => css`
     color: ${theme.color.blue};

--- a/frontend/src/pages/PublicSearchPage.tsx
+++ b/frontend/src/pages/PublicSearchPage.tsx
@@ -328,7 +328,7 @@ const LoadImage = styled.div<LoadImageStyleProps>`
   background-repeat: no-repeat;
   background-size: contain;
   margin: 0 auto;
-  margin-top: 3.5rem;
+  margin-top: 6rem;
 
   ${({ isSearching, isFrogJumping }) => css`
     display: ${isSearching ? 'block' : 'none'};

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -123,6 +123,7 @@ const Title = styled.h2`
   margin-top: 0.5rem;
   margin-bottom: 1rem;
   text-align: center;
+  word-break: break-all;
 
   ${({ theme }) => css`
     font-size: ${theme.fontSize.medium};


### PR DESCRIPTION
closes #400 

## 작업 내용
- 하트 위치 변경
- 태그의 flex를 제거하고 inline-block으로 변경
- 태그 검색 기능을 추가하면서 검색 시 기존에 history.replace를 하던 것에서 push도 받을 수 있도록 변경
- 제목에 break-word를 적용해 만약 제목이 길어졌을 경우를 대비하였음(사실 글자 수 제한이 있어서 그럴 일은 없지만 우선 적용해두었습니다.)
- 검색 중일 때 나오는 이미지의 margin-top을 변경
- 해시태그 20글자 제한(스낵바)
## 주의 사항
- 없음