### PR TITLE
UI15 - 검색 페이지의 문제집, 태그, 작성자 UI를 삭제한다

### DIFF
--- a/frontend/src/pages/PublicSearchPage.tsx
+++ b/frontend/src/pages/PublicSearchPage.tsx
@@ -66,19 +66,20 @@ const PublicSearchPage = () => {
           onFocus={() => setIsFocus(true)}
           onBlur={() => setIsFocus(false)}
         >
-          <SearchInputWrapper>
-            <SearchInput
-              value={searchKeyword}
-              onChange={({ target }) => setSearchKeyword(target.value)}
-              placeholder={'문제집을 검색해보세요.'}
-              ref={searchInputRef}
-            />
-            {searchKeyword && (
-              <button type="button" onClick={() => setSearchKeyword('')}>
-                <SearchCloseIcon width="0.5rem" height="0.5rem" />
-              </button>
-            )}
-          </SearchInputWrapper>
+          <SearchInput
+            value={searchKeyword}
+            onChange={({ target }) => setSearchKeyword(target.value)}
+            placeholder={'문제집을 검색해보세요.'}
+            ref={searchInputRef}
+          />
+          {searchKeyword && (
+            <KeywordResetButton
+              type="button"
+              onClick={() => setSearchKeyword('')}
+            >
+              <SearchCloseIcon width="0.5rem" height="0.5rem" />
+            </KeywordResetButton>
+          )}
           <SearchButton isFocus={isFocus}>
             <SearchIcon width="1.3rem" height="1.3rem" />
           </SearchButton>
@@ -93,7 +94,8 @@ const StyledPageTemplate = styled(PageTemplate)`
 `;
 
 const SearchBar = styled.form<SearchBarStyleProps>`
-  ${Flex({ items: 'center' })};
+  ${Flex({ justify: 'space-between', items: 'center' })};
+  position: relative;
   width: 100%;
   height: 3rem;
   margin-bottom: 1.5rem;
@@ -123,14 +125,8 @@ const SearchBar = styled.form<SearchBarStyleProps>`
   `};
 `;
 
-const SearchInputWrapper = styled.div`
-  width: 90%;
-  height: 100%;
-  margin: 0 0.3rem;
-`;
-
 const SearchInput = styled.input`
-  width: 90%;
+  width: 80%;
   height: 100%;
   outline: none;
   border: none;
@@ -138,6 +134,11 @@ const SearchInput = styled.input`
   ${({ theme }) => css`
     font-size: ${theme.fontSize.default};
   `}
+`;
+
+const KeywordResetButton = styled.button`
+  position: absolute;
+  right: 3rem;
 `;
 
 const SearchButton = styled.button<SearchButtonStyleProps>`


### PR DESCRIPTION
closes #437 

## 작업 내용
- tab, load animation, searchResult 삭제
- `autofocus={true}` 삭제
- SearchBar -> form tag로 변경
- searchInputRef 추가

## 주의 사항
- ui 관련 이슈라 hook 쪽은 차차 정리할 생각입니다!
- 첫 화면 진입 시 보여줄 콘텐츠가 생기면서 검색을 바로 제공해주지 않아도 될 것 같아 `autofocus`를 삭제 해봤는데 의견 부탁해요 ☺️
- 검색어를 reset 했을 때 포커싱이 풀리면서 검색을 위해 다시 한번 더 Searchbar를 눌러야 하는데, 사용성을 고려해서 reset이 되어도 포커싱이 되게끔 수정했습니다! 이 부분도 의견 부탁해요~~