### PR TITLE
UI17 - 검색 상세 페이지에서 바텀 모달을 추가한다(태그, 작성자 필터링)

### DIFF
--- a/frontend/src/assets/tick.svg
+++ b/frontend/src/assets/tick.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<g>
+	<g>
+		<path d="M504.502,75.496c-9.997-9.998-26.205-9.998-36.204,0L161.594,382.203L43.702,264.311c-9.997-9.998-26.205-9.997-36.204,0
+			c-9.998,9.997-9.998,26.205,0,36.203l135.994,135.992c9.994,9.997,26.214,9.99,36.204,0L504.502,111.7
+			C514.5,101.703,514.499,85.494,504.502,75.496z"/>
+	</g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/frontend/src/components/MultiFilterSelector.tsx
+++ b/frontend/src/components/MultiFilterSelector.tsx
@@ -7,18 +7,24 @@ import CheckIcon from '../assets/tick.svg';
 import { useModal } from '../hooks';
 import { Flex, scrollBarStyle } from '../styles';
 
+interface Props {
+  type: MultiFilterTypes;
+  values: MultiFilterValue[];
+  setMultiFilters: React.Dispatch<React.SetStateAction<MultiFilter[]>>;
+}
+
 type MultiFilterTypes = '태그' | '작성자';
 
-interface MultiFilterData {
+interface MultiFilter {
+  id: number;
+  type: MultiFilterTypes;
+  values: MultiFilterValue[];
+}
+
+interface MultiFilterValue {
   id: number;
   name: string;
   isSelected: boolean;
-}
-
-interface Props {
-  type: MultiFilterTypes;
-  data: MultiFilterData[];
-  setSelectedMultiFilters: React.Dispatch<React.SetStateAction<MultiFilters[]>>;
 }
 
 interface SearchBarStyleProps {
@@ -29,39 +35,33 @@ interface MultiFilterItemStyleProps {
   isSelected: boolean;
 }
 
-interface MultiFilters {
-  id: number;
-  type: MultiFilterTypes;
-  data: MultiFilterData[];
-}
-
 const MultiFilterSelector = ({
   type,
-  data,
-  setSelectedMultiFilters,
+  values: data,
+  setMultiFilters,
 }: Props) => {
   const { closeModal } = useModal();
 
   const [filterKeyword, setFilterKeyword] = useState('');
   const [isSearchBarFocus, setIsSearchBarFocus] = useState(false);
-  const [multiFilterItemData, setMultiFilterItemData] = useState(data);
+  const [values, setValues] = useState(data);
 
   const checkFilterItem = (name: string) => {
-    setMultiFilterItemData((prevValue) =>
-      prevValue.map((value) => {
-        if (value.name !== name) return value;
+    setValues((prevValue) =>
+      prevValue.map((item) => {
+        if (item.name !== name) return item;
 
-        return { ...value, isSelected: !value.isSelected };
+        return { ...item, isSelected: !item.isSelected };
       })
     );
   };
 
-  const setSelectedData = () => {
-    setSelectedMultiFilters((prevValue) =>
-      prevValue.map((value) => {
-        if (value.type !== type) return value;
+  const setSelectedValues = () => {
+    setMultiFilters((prevValue) =>
+      prevValue.map((item) => {
+        if (item.type !== type) return item;
 
-        return { ...value, data: multiFilterItemData };
+        return { ...item, values };
       })
     );
   };
@@ -86,7 +86,7 @@ const MultiFilterSelector = ({
         )}
       </SearchBar>
       <MultiFilterList>
-        {multiFilterItemData.map(({ id, name, isSelected }) => (
+        {values.map(({ id, name, isSelected }) => (
           <MultiFilterItem
             key={id}
             isSelected={isSelected}
@@ -100,7 +100,7 @@ const MultiFilterSelector = ({
       <Confirm
         type="button"
         onClick={() => {
-          setSelectedData();
+          setSelectedValues();
           closeModal();
         }}
       >

--- a/frontend/src/components/MultiFilterSelector.tsx
+++ b/frontend/src/components/MultiFilterSelector.tsx
@@ -6,25 +6,16 @@ import SearchCloseIcon from '../assets/cross-mark.svg';
 import CheckIcon from '../assets/tick.svg';
 import { useModal } from '../hooks';
 import { Flex, scrollBarStyle } from '../styles';
+import {
+  MultiFilter,
+  MultiFilterTypes,
+  MultiFilterValue,
+} from '../types/filter';
 
 interface Props {
   type: MultiFilterTypes;
   values: MultiFilterValue[];
   setMultiFilters: React.Dispatch<React.SetStateAction<MultiFilter[]>>;
-}
-
-type MultiFilterTypes = '태그' | '작성자';
-
-interface MultiFilter {
-  id: number;
-  type: MultiFilterTypes;
-  values: MultiFilterValue[];
-}
-
-interface MultiFilterValue {
-  id: number;
-  name: string;
-  isSelected: boolean;
 }
 
 interface SearchBarStyleProps {

--- a/frontend/src/components/MultiFilterSelector.tsx
+++ b/frontend/src/components/MultiFilterSelector.tsx
@@ -81,7 +81,7 @@ const MultiFilterSelector = ({
           onChange={({ target }) => setFilterKeyword(target.value)}
           name="search"
           role="search"
-          placeholder={'문제집을 검색해보세요.'}
+          placeholder={`${type}를 입력해보세요.`}
         />
         {filterKeyword && (
           <button type="button" onClick={() => setFilterKeyword('')}>

--- a/frontend/src/components/MultiFilterSelector.tsx
+++ b/frontend/src/components/MultiFilterSelector.tsx
@@ -1,46 +1,11 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import SearchCloseIcon from '../assets/cross-mark.svg';
 import CheckIcon from '../assets/tick.svg';
 import { useModal } from '../hooks';
 import { Flex, scrollBarStyle } from '../styles';
-
-const dummyList = [
-  {
-    id: 1,
-    name: 'java',
-  },
-  {
-    id: 2,
-    name: 'javascript',
-  },
-  {
-    id: 3,
-    name: '자바',
-  },
-  {
-    id: 4,
-    name: '자스',
-  },
-  {
-    id: 5,
-    name: '자바스크립트',
-  },
-  {
-    id: 6,
-    name: 'javascriptjavascriptjavascriptjavascript',
-  },
-  {
-    id: 7,
-    name: '자스스스',
-  },
-  {
-    id: 8,
-    name: 'ㅁㄴㅇㅁㄴㅇ',
-  },
-];
 
 type MultiFilterTypes = '태그' | '작성자';
 
@@ -91,27 +56,15 @@ const MultiFilterSelector = ({
     );
   };
 
-  const setSelectedData = (initialData?: MultiFilterData[]) => {
+  const setSelectedData = () => {
     setSelectedMultiFilters((prevValue) =>
       prevValue.map((value) => {
         if (value.type !== type) return value;
 
-        return { ...value, data: initialData ?? multiFilterItemData };
+        return { ...value, data: multiFilterItemData };
       })
     );
   };
-
-  useEffect(() => {
-    if (data.length !== 0) return;
-
-    const initialData = dummyList.map((dummy) => ({
-      ...dummy,
-      isSelected: false,
-    }));
-
-    setMultiFilterItemData(initialData);
-    setSelectedData(initialData);
-  }, []);
 
   return (
     <>

--- a/frontend/src/components/MultiFilterSelector.tsx
+++ b/frontend/src/components/MultiFilterSelector.tsx
@@ -1,0 +1,198 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React, { useState } from 'react';
+
+import SearchCloseIcon from '../assets/cross-mark.svg';
+import CheckIcon from '../assets/tick.svg';
+import { useModal } from '../hooks';
+import { Flex, scrollBarStyle } from '../styles';
+
+type MultiFilterTypes = '태그' | '작성자';
+
+interface Props {
+  data: { id: number; name: string }[];
+  type: MultiFilterTypes;
+  selectedData: string[];
+  setSelectedMultiFilters: React.Dispatch<React.SetStateAction<MultiFilters[]>>;
+}
+
+interface SearchBarStyleProps {
+  isFocus: boolean;
+}
+
+interface MultiFilterItemStyleProps {
+  isSelected: boolean;
+}
+
+interface MultiFilters {
+  id: number;
+  type: MultiFilterTypes;
+  data: string[];
+}
+
+const MultiFilterSelector = ({
+  data,
+  type,
+  selectedData,
+  setSelectedMultiFilters,
+}: Props) => {
+  const { closeModal } = useModal();
+
+  const [filterKeyword, setFilterKeyword] = useState('');
+  const [isSearchBarFocus, setIsSearchBarFocus] = useState(false);
+  const [multiFilterData, setMultiFilterData] = useState(
+    data.map((value) => ({
+      ...value,
+      isSelected: selectedData.includes(value.name),
+    }))
+  );
+
+  const setSelectedData = (selectedDataName: string, isAdd: boolean) => {
+    setSelectedMultiFilters((prevValue) =>
+      prevValue.map((value) => {
+        if (value.type !== type) return value;
+
+        return {
+          ...value,
+          data: isAdd
+            ? [...value.data, selectedDataName]
+            : value.data.filter((name) => name !== selectedDataName),
+        };
+      })
+    );
+
+    setMultiFilterData((prevValue) =>
+      prevValue.map((value) => {
+        if (value.name !== selectedDataName) return value;
+
+        return { ...value, isSelected: !value.isSelected };
+      })
+    );
+  };
+
+  return (
+    <>
+      <Title>{type} 선택</Title>
+      <SearchBar isFocus={isSearchBarFocus}>
+        <SearchInput
+          onFocus={() => setIsSearchBarFocus(true)}
+          onBlur={() => setIsSearchBarFocus(false)}
+          value={filterKeyword}
+          onChange={({ target }) => setFilterKeyword(target.value)}
+          name="search"
+          role="search"
+          placeholder={'문제집을 검색해보세요.'}
+        />
+        {filterKeyword && (
+          <button type="button" onClick={() => setFilterKeyword('')}>
+            <SearchCloseIcon width="0.5rem" height="0.5rem" />
+          </button>
+        )}
+      </SearchBar>
+      <MultiFilterList>
+        {multiFilterData.map(({ id, name, isSelected }) => (
+          <MultiFilterItem
+            key={id}
+            onClick={() => setSelectedData(name, !isSelected)}
+            isSelected={isSelected}
+          >
+            <div>{name}</div>
+            {isSelected && <CheckIcon width="1rem" height="1rem" />}
+          </MultiFilterItem>
+        ))}
+      </MultiFilterList>
+      <Confirm type="button" onClick={closeModal}>
+        확인
+      </Confirm>
+    </>
+  );
+};
+
+const Title = styled.h3`
+  text-align: center;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+
+  ${({ theme }) => css`
+    font-size: ${theme.fontSize.default};
+    font-weight: ${theme.fontWeight.semiBold};
+  `}
+`;
+
+const SearchBar = styled.div<SearchBarStyleProps>`
+  ${Flex({ justify: 'space-between', items: 'center' })};
+  position: relative;
+  width: 100%;
+  height: 3rem;
+  margin-bottom: 1.5rem;
+  padding: 0.5rem 1rem;
+  transition: all 0.2s ease;
+
+  ${({ theme, isFocus }) => css`
+    background-color: ${theme.color.white};
+    border: 1px solid ${isFocus ? theme.color.green : theme.color.gray_3};
+  `};
+`;
+
+const SearchInput = styled.input`
+  width: 100%;
+  height: 100%;
+  outline: none;
+  border: none;
+  margin-right: 1rem;
+
+  ${({ theme }) => css`
+    font-size: ${theme.fontSize.default};
+  `}
+`;
+
+const MultiFilterList = styled.ul`
+  height: 30vh;
+  overflow-y: auto;
+  word-break: break-all;
+  margin-bottom: 3.5rem;
+
+  ${scrollBarStyle}
+`;
+
+const MultiFilterItem = styled.li<MultiFilterItemStyleProps>`
+  ${Flex({ justify: 'space-between', items: 'center' })};
+  padding: 1rem 0;
+  cursor: pointer;
+  line-height: 1.5;
+
+  ${({ theme, isSelected }) => css`
+    ${isSelected &&
+    css`
+      color: ${theme.color.green};
+    `}
+
+    & > div {
+      width: 80%;
+
+      &:hover {
+        opacity: 0.6;
+      }
+    }
+
+    & > svg {
+      margin-right: 1rem;
+      fill: ${theme.color.green};
+    }
+  `}
+`;
+
+const Confirm = styled.button`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 1rem 0;
+  text-align: center;
+  width: 100%;
+
+  ${({ theme }) => css`
+    border-top: 1px solid ${theme.color.gray_5};
+  `}
+`;
+
+export default MultiFilterSelector;

--- a/frontend/src/components/MultiFilterSelector.tsx
+++ b/frontend/src/components/MultiFilterSelector.tsx
@@ -1,18 +1,58 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import SearchCloseIcon from '../assets/cross-mark.svg';
 import CheckIcon from '../assets/tick.svg';
 import { useModal } from '../hooks';
 import { Flex, scrollBarStyle } from '../styles';
 
+const dummyList = [
+  {
+    id: 1,
+    name: 'java',
+  },
+  {
+    id: 2,
+    name: 'javascript',
+  },
+  {
+    id: 3,
+    name: '자바',
+  },
+  {
+    id: 4,
+    name: '자스',
+  },
+  {
+    id: 5,
+    name: '자바스크립트',
+  },
+  {
+    id: 6,
+    name: 'javascriptjavascriptjavascriptjavascript',
+  },
+  {
+    id: 7,
+    name: '자스스스',
+  },
+  {
+    id: 8,
+    name: 'ㅁㄴㅇㅁㄴㅇ',
+  },
+];
+
 type MultiFilterTypes = '태그' | '작성자';
 
+interface MultiFilterData {
+  id: number;
+  name: string;
+  isSelected: boolean;
+}
+
 interface Props {
-  data: { id: number; name: string }[];
   type: MultiFilterTypes;
-  selectedData: string[];
+  data: MultiFilterData[];
   setSelectedMultiFilters: React.Dispatch<React.SetStateAction<MultiFilters[]>>;
 }
 
@@ -27,48 +67,51 @@ interface MultiFilterItemStyleProps {
 interface MultiFilters {
   id: number;
   type: MultiFilterTypes;
-  data: string[];
+  data: MultiFilterData[];
 }
 
 const MultiFilterSelector = ({
-  data,
   type,
-  selectedData,
+  data,
   setSelectedMultiFilters,
 }: Props) => {
   const { closeModal } = useModal();
 
   const [filterKeyword, setFilterKeyword] = useState('');
   const [isSearchBarFocus, setIsSearchBarFocus] = useState(false);
-  const [multiFilterData, setMultiFilterData] = useState(
-    data.map((value) => ({
-      ...value,
-      isSelected: selectedData.includes(value.name),
-    }))
-  );
+  const [multiFilterItemData, setMultiFilterItemData] = useState(data);
 
-  const setSelectedData = (selectedDataName: string, isAdd: boolean) => {
-    setSelectedMultiFilters((prevValue) =>
+  const checkFilterItem = (name: string) => {
+    setMultiFilterItemData((prevValue) =>
       prevValue.map((value) => {
-        if (value.type !== type) return value;
-
-        return {
-          ...value,
-          data: isAdd
-            ? [...value.data, selectedDataName]
-            : value.data.filter((name) => name !== selectedDataName),
-        };
-      })
-    );
-
-    setMultiFilterData((prevValue) =>
-      prevValue.map((value) => {
-        if (value.name !== selectedDataName) return value;
+        if (value.name !== name) return value;
 
         return { ...value, isSelected: !value.isSelected };
       })
     );
   };
+
+  const setSelectedData = (initialData?: MultiFilterData[]) => {
+    setSelectedMultiFilters((prevValue) =>
+      prevValue.map((value) => {
+        if (value.type !== type) return value;
+
+        return { ...value, data: initialData ?? multiFilterItemData };
+      })
+    );
+  };
+
+  useEffect(() => {
+    if (data.length !== 0) return;
+
+    const initialData = dummyList.map((dummy) => ({
+      ...dummy,
+      isSelected: false,
+    }));
+
+    setMultiFilterItemData(initialData);
+    setSelectedData(initialData);
+  }, []);
 
   return (
     <>
@@ -90,18 +133,24 @@ const MultiFilterSelector = ({
         )}
       </SearchBar>
       <MultiFilterList>
-        {multiFilterData.map(({ id, name, isSelected }) => (
+        {multiFilterItemData.map(({ id, name, isSelected }) => (
           <MultiFilterItem
             key={id}
-            onClick={() => setSelectedData(name, !isSelected)}
             isSelected={isSelected}
+            onClick={() => checkFilterItem(name)}
           >
             <div>{name}</div>
             {isSelected && <CheckIcon width="1rem" height="1rem" />}
           </MultiFilterItem>
         ))}
       </MultiFilterList>
-      <Confirm type="button" onClick={closeModal}>
+      <Confirm
+        type="button"
+        onClick={() => {
+          setSelectedData();
+          closeModal();
+        }}
+      >
         확인
       </Confirm>
     </>

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -29,3 +29,4 @@ export { default as SelectBox } from './SelectBox';
 export { default as TextAreaField } from './TextAreaField';
 export { default as Timer } from './Timer';
 export { default as LoadingSpinner } from './LoadingSpinner';
+export { default as MultiFilterSelector } from './MultiFilterSelector';

--- a/frontend/src/contexts/ModalProvider.tsx
+++ b/frontend/src/contexts/ModalProvider.tsx
@@ -75,10 +75,14 @@ const ModalProvider = ({ children }: Props) => {
     setCloseIcon(closeIcon ?? '');
     setType(type ?? 'bottom');
     setIsOpened(true);
+
+    document.body.style.overflow = 'hidden';
   };
 
   const closeModal = () => {
     setIsOpened(false);
+
+    document.body.style.overflow = '';
   };
 
   const deleteContent = () => {

--- a/frontend/src/pages/PublicSearchResultLoadable.tsx
+++ b/frontend/src/pages/PublicSearchResultLoadable.tsx
@@ -11,7 +11,7 @@ const PublicSearchResultLoadable = () => (
     <StyledPageTemplate isScroll={true}>
       <Title />
       <Filter>
-        {[...Array(4)].map((_, index) => (
+        {[...Array(6)].map((_, index) => (
           <Button
             key={index}
             shape="round"
@@ -41,7 +41,6 @@ const Title = styled.div`
   width: 40%;
   height: 1.5rem;
   margin: 0 auto;
-  margin-top: 0.5rem;
   margin-bottom: 1rem;
 
   ${loadContent};
@@ -49,14 +48,15 @@ const Title = styled.div`
 
 const Filter = styled.div`
   ${Flex()};
-  flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 1rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
+  overflow-x: hidden;
 
   & > button {
     width: 4rem;
     height: 2rem;
+    flex-shrink: 0;
   }
 `;
 

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -23,47 +23,18 @@ import { isMobile } from '../utils';
 import PageTemplate from './PageTemplate';
 import PublicWorkbookLoadable from './PublicSearchResultLoadable';
 
-const dummy = [
-  {
-    id: 1,
-    name: 'java',
-  },
-  {
-    id: 2,
-    name: 'javascript',
-  },
-  {
-    id: 3,
-    name: '자바',
-  },
-  {
-    id: 4,
-    name: '자스',
-  },
-  {
-    id: 5,
-    name: '자바스크립트',
-  },
-  {
-    id: 6,
-    name: 'javascriptjavascriptjavascriptjavascript',
-  },
-  {
-    id: 7,
-    name: '자스스스',
-  },
-  {
-    id: 8,
-    name: 'ㅁㄴㅇㅁㄴㅇ',
-  },
-];
-
 type MultiFilterTypes = '태그' | '작성자';
+
+interface MultiFilterData {
+  id: number;
+  name: string;
+  isSelected: boolean;
+}
 
 interface MultiFilters {
   id: number;
   type: MultiFilterTypes;
-  data: string[];
+  data: MultiFilterData[];
 }
 
 const multiFilters: MultiFilters[] = [
@@ -77,6 +48,10 @@ const singleFilters = [
   { id: 3, type: '이름 순', criteria: SEARCH_CRITERIA.NAME },
   { id: 4, type: '카드 개수 순', criteria: SEARCH_CRITERIA.COUNT },
 ];
+
+const hasSelectedData = (data: MultiFilterData[]) => {
+  return data.some(({ isSelected }) => isSelected);
+};
 
 const PublicSearchResultPage = () => {
   const {
@@ -102,7 +77,7 @@ const PublicSearchResultPage = () => {
 
   const isFiltered =
     currentFilterId !== singleFilters[0].id ||
-    selectedMultiFilters.some(({ data }) => data.length > 0);
+    selectedMultiFilters.find(({ data }) => hasSelectedData(data));
 
   const setSingleFilterData = (
     id: number,
@@ -125,7 +100,13 @@ const PublicSearchResultPage = () => {
   const resetFilterData = () => {
     setSingleFilterData(singleFilters[0].id, singleFilters[0].criteria);
     setSelectedMultiFilters((prevValue) =>
-      prevValue.map((value) => ({ ...value, data: [] }))
+      prevValue.map((multiFilterItem) => ({
+        ...multiFilterItem,
+        data: multiFilterItem.data.map((value) => ({
+          ...value,
+          isSelected: false,
+        })),
+      }))
     );
   };
 
@@ -169,7 +150,7 @@ const PublicSearchResultPage = () => {
                     key={id}
                     shape="round"
                     backgroundColor={
-                      selectedMultiFilters[index].data.length > 0
+                      hasSelectedData(selectedMultiFilters[index].data)
                         ? 'green'
                         : 'gray_5'
                     }
@@ -179,8 +160,7 @@ const PublicSearchResultPage = () => {
                         content: (
                           <MultiFilterSelector
                             type={type}
-                            data={dummy}
-                            selectedData={selectedMultiFilters[index].data}
+                            data={selectedMultiFilters[index].data}
                             setSelectedMultiFilters={setSelectedMultiFilters}
                           />
                         ),
@@ -212,9 +192,13 @@ const PublicSearchResultPage = () => {
               <SelectedMultiFilterWrapper>
                 {selectedMultiFilters.map(
                   ({ id, type, data }) =>
-                    data.length > 0 && (
+                    hasSelectedData(data) && (
                       <SelectedMultiFilter key={id}>
-                        선택된 {type}: {data.join(', ')}
+                        선택된 {type}:{' '}
+                        {data
+                          .filter(({ isSelected }) => isSelected)
+                          .map(({ name }) => name)
+                          .join(', ')}
                       </SelectedMultiFilter>
                     )
                 )}

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -155,66 +155,70 @@ const PublicSearchResultPage = () => {
         ) : (
           <>
             <Title>{keyword} 검색 결과</Title>
-            <Filter>
-              {singleFilters.map(({ id, type, criteria }) => (
-                <Button
-                  key={id}
-                  shape="round"
-                  backgroundColor={currentFilterId === id ? 'green' : 'gray_5'}
-                  inversion={true}
-                  onClick={() => {
-                    if (id === currentFilterId) return;
+            <FilterWrapper>
+              <Filter>
+                {isFiltered && (
+                  <FilterResetButton onClick={resetFilterData}>
+                    <span>초기화</span>
+                    <ResetIcon width="1rem" height="1rem" />
+                  </FilterResetButton>
+                )}
+                {multiFilters.map(({ id, type }, index) => (
+                  <MultiFilterButton
+                    key={id}
+                    shape="round"
+                    backgroundColor={
+                      selectedMultiFilters[index].data.length > 0
+                        ? 'green'
+                        : 'gray_5'
+                    }
+                    inversion={true}
+                    onClick={() => {
+                      openModal({
+                        content: (
+                          <MultiFilterSelector
+                            type={type}
+                            data={dummy}
+                            selectedData={selectedMultiFilters[index].data}
+                            setSelectedMultiFilters={setSelectedMultiFilters}
+                          />
+                        ),
+                      });
+                    }}
+                  >
+                    {type}
+                    <DownIcon width="1rem" height="1rem" />
+                  </MultiFilterButton>
+                ))}
+                {singleFilters.map(({ id, type, criteria }) => (
+                  <Button
+                    key={id}
+                    shape="round"
+                    backgroundColor={
+                      currentFilterId === id ? 'green' : 'gray_5'
+                    }
+                    inversion={true}
+                    onClick={() => {
+                      if (id === currentFilterId) return;
 
-                    setSingleFilterData(id, criteria);
-                  }}
-                >
-                  {type}
-                </Button>
-              ))}
-              {multiFilters.map(({ id, type }, index) => (
-                <MultiFilterButton
-                  key={id}
-                  shape="round"
-                  backgroundColor={
-                    selectedMultiFilters[index].data.length > 0
-                      ? 'green'
-                      : 'gray_5'
-                  }
-                  inversion={true}
-                  onClick={() => {
-                    openModal({
-                      content: (
-                        <MultiFilterSelector
-                          type={type}
-                          data={dummy}
-                          selectedData={selectedMultiFilters[index].data}
-                          setSelectedMultiFilters={setSelectedMultiFilters}
-                        />
-                      ),
-                    });
-                  }}
-                >
-                  {type}
-                  <DownIcon width="1rem" height="1rem" />
-                </MultiFilterButton>
-              ))}
-              {isFiltered && (
-                <FilterResetButton onClick={resetFilterData}>
-                  <span>초기화</span>
-                  <ResetIcon width="1rem" height="1rem" />
-                </FilterResetButton>
-              )}
-            </Filter>
-            <SelectedMultiFilterWrapper>
-              {selectedMultiFilters.map(
-                ({ id, type, data }) =>
-                  data.length > 0 && (
-                    <SelectedMultiFilter key={id}>
-                      선택된 {type}: {data.join(', ')}
-                    </SelectedMultiFilter>
-                  )
-              )}
-            </SelectedMultiFilterWrapper>
+                      setSingleFilterData(id, criteria);
+                    }}
+                  >
+                    {type}
+                  </Button>
+                ))}
+              </Filter>
+              <SelectedMultiFilterWrapper>
+                {selectedMultiFilters.map(
+                  ({ id, type, data }) =>
+                    data.length > 0 && (
+                      <SelectedMultiFilter key={id}>
+                        선택된 {type}: {data.join(', ')}
+                      </SelectedMultiFilter>
+                    )
+                )}
+              </SelectedMultiFilterWrapper>
+            </FilterWrapper>
             <PublicWorkbookList
               isLoading={isLoading}
               publicWorkbooks={workbookSearchResult}
@@ -246,13 +250,25 @@ const NoSearchResult = styled.div`
 `;
 
 const Title = styled.h2`
-  margin-top: 0.5rem;
-  margin-bottom: 1rem;
-  text-align: center;
   word-break: break-all;
+  text-align: center;
 
   ${({ theme }) => css`
     font-size: ${theme.fontSize.medium};
+  `}
+`;
+
+const FilterWrapper = styled.div`
+  position: sticky;
+  top: 3.75rem;
+  padding: 0.1rem 1.25rem 0.5rem 1.25rem;
+  z-index: 1;
+  transform: translateX(-1.25rem);
+  width: calc(100% + 2.5rem);
+  margin-bottom: 0.5rem;
+
+  ${({ theme }) => css`
+    background-color: ${theme.color.gray_0};
   `}
 `;
 
@@ -267,19 +283,29 @@ const MultiFilterButton = styled(Button)`
 
 const Filter = styled.div`
   ${Flex()};
-  flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 1rem;
   margin-bottom: 0.5rem;
+  overflow-x: auto;
+
+  & > button {
+    flex-shrink: 0;
+  }
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const SelectedMultiFilterWrapper = styled.div`
-  margin-bottom: 1rem;
-  word-break: break-all;
+  margin-top: 0.5rem;
+  white-space: nowrap;
 `;
 
 const SelectedMultiFilter = styled.div`
-  margin-bottom: 0.2rem;
+  margin-bottom: 0.3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const FilterResetButton = styled.button`

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -4,7 +4,12 @@ import React, { useEffect, useState } from 'react';
 
 import DownIcon from '../assets/chevron-down-solid.svg';
 import ResetIcon from '../assets/rotate-left-circular-arrow-interface-symbol.svg';
-import { Button, MainHeader, PublicWorkbookList } from '../components';
+import {
+  Button,
+  MainHeader,
+  MultiFilterSelector,
+  PublicWorkbookList,
+} from '../components';
 import { SEARCH_CRITERIA } from '../constants';
 import {
   useModal,
@@ -17,22 +22,59 @@ import { ValueOf } from '../types/utils';
 import PageTemplate from './PageTemplate';
 import PublicWorkbookLoadable from './PublicSearchResultLoadable';
 
+const dummy = [
+  {
+    id: 1,
+    name: 'java',
+  },
+  {
+    id: 2,
+    name: 'javascript',
+  },
+  {
+    id: 3,
+    name: '자바',
+  },
+  {
+    id: 4,
+    name: '자스',
+  },
+  {
+    id: 5,
+    name: '자바스크립트',
+  },
+  {
+    id: 6,
+    name: 'javascriptjavascriptjavascriptjavascript',
+  },
+  {
+    id: 7,
+    name: '자스스스',
+  },
+  {
+    id: 8,
+    name: 'ㅁㄴㅇㅁㄴㅇ',
+  },
+];
+
+type MultiFilterTypes = '태그' | '작성자';
+
 interface MultiFilters {
   id: number;
-  name: string;
+  type: MultiFilterTypes;
   data: string[];
 }
 
 const multiFilters: MultiFilters[] = [
-  { id: 1, name: '태그', data: [] },
-  { id: 2, name: '작성자', data: [] },
+  { id: 1, type: '태그', data: [] },
+  { id: 2, type: '작성자', data: [] },
 ];
 
 const singleFilters = [
-  { id: 1, name: '최신순', criteria: SEARCH_CRITERIA.DATE },
-  { id: 2, name: '좋아요 순', criteria: SEARCH_CRITERIA.HEART },
-  { id: 3, name: '이름 순', criteria: SEARCH_CRITERIA.NAME },
-  { id: 4, name: '카드 개수 순', criteria: SEARCH_CRITERIA.COUNT },
+  { id: 1, type: '최신순', criteria: SEARCH_CRITERIA.DATE },
+  { id: 2, type: '좋아요 순', criteria: SEARCH_CRITERIA.HEART },
+  { id: 3, type: '이름 순', criteria: SEARCH_CRITERIA.NAME },
+  { id: 4, type: '카드 개수 순', criteria: SEARCH_CRITERIA.COUNT },
 ];
 
 const PublicSearchResultPage = () => {
@@ -79,19 +121,6 @@ const PublicSearchResultPage = () => {
     searchForPublicWorkbook(initialValue);
   };
 
-  const setMultiFilterData = (filterName: string, data: string) => {
-    setSelectedMultiFilters((prevValue) =>
-      prevValue.map((value) => {
-        if (value.name !== filterName) return value;
-
-        return {
-          ...value,
-          data: [...value.data, data],
-        };
-      })
-    );
-  };
-
   const resetFilterData = () => {
     setSingleFilterData(singleFilters[0].id, singleFilters[0].criteria);
     setSelectedMultiFilters((prevValue) =>
@@ -127,7 +156,7 @@ const PublicSearchResultPage = () => {
           <>
             <Title>{keyword} 검색 결과</Title>
             <Filter>
-              {singleFilters.map(({ id, name, criteria }) => (
+              {singleFilters.map(({ id, type, criteria }) => (
                 <Button
                   key={id}
                   shape="round"
@@ -139,10 +168,10 @@ const PublicSearchResultPage = () => {
                     setSingleFilterData(id, criteria);
                   }}
                 >
-                  {name}
+                  {type}
                 </Button>
               ))}
-              {multiFilters.map(({ id, name }, index) => (
+              {multiFilters.map(({ id, type }, index) => (
                 <MultiFilterButton
                   key={id}
                   shape="round"
@@ -154,17 +183,18 @@ const PublicSearchResultPage = () => {
                   inversion={true}
                   onClick={() => {
                     openModal({
-                      title: name,
                       content: (
-                        <div onClick={() => setMultiFilterData(name, 'hello')}>
-                          hello
-                        </div>
+                        <MultiFilterSelector
+                          type={type}
+                          data={dummy}
+                          selectedData={selectedMultiFilters[index].data}
+                          setSelectedMultiFilters={setSelectedMultiFilters}
+                        />
                       ),
-                      closeIcon: 'back',
                     });
                   }}
                 >
-                  {name}
+                  {type}
                   <DownIcon width="1rem" height="1rem" />
                 </MultiFilterButton>
               ))}
@@ -177,10 +207,10 @@ const PublicSearchResultPage = () => {
             </Filter>
             <SelectedMultiFilterWrapper>
               {selectedMultiFilters.map(
-                ({ id, name, data }) =>
+                ({ id, type, data }) =>
                   data.length > 0 && (
                     <SelectedMultiFilter key={id}>
-                      선택된 {name}: {data.join(', ')}
+                      선택된 {type}: {data.join(', ')}
                     </SelectedMultiFilter>
                   )
               )}

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -75,9 +75,12 @@ const PublicSearchResultPage = () => {
       singleFilters[0].id
   );
 
+  const hasMultiFilterSelected = selectedMultiFilters.find(({ data }) =>
+    hasSelectedData(data)
+  );
+
   const isFiltered =
-    currentFilterId !== singleFilters[0].id ||
-    selectedMultiFilters.find(({ data }) => hasSelectedData(data));
+    currentFilterId !== singleFilters[0].id || hasMultiFilterSelected;
 
   const setSingleFilterData = (
     id: number,
@@ -95,6 +98,19 @@ const PublicSearchResultPage = () => {
     setIsSearching(true);
     routePublicSearchResultQuery(initialValue);
     searchForPublicWorkbook(initialValue);
+  };
+
+  const removeMultiFilterItem = (type: MultiFilterTypes, itemId: number) => {
+    setSelectedMultiFilters((prevValue) =>
+      prevValue.map((multiFilterItem) => {
+        if (multiFilterItem.type !== type) return multiFilterItem;
+
+        return {
+          ...multiFilterItem,
+          data: multiFilterItem.data.filter(({ id }) => id !== itemId),
+        };
+      })
+    );
   };
 
   const resetFilterData = () => {
@@ -189,20 +205,28 @@ const PublicSearchResultPage = () => {
                   </Button>
                 ))}
               </Filter>
-              <SelectedMultiFilterWrapper>
-                {selectedMultiFilters.map(
-                  ({ id, type, data }) =>
-                    hasSelectedData(data) && (
-                      <SelectedMultiFilter key={id}>
-                        선택된 {type}:{' '}
-                        {data
-                          .filter(({ isSelected }) => isSelected)
-                          .map(({ name }) => name)
-                          .join(', ')}
-                      </SelectedMultiFilter>
-                    )
-                )}
-              </SelectedMultiFilterWrapper>
+              {hasMultiFilterSelected && (
+                <SelectedMultiFilterWrapper>
+                  {selectedMultiFilters.map(({ type, data }) =>
+                    data
+                      .filter(({ isSelected }) => isSelected)
+                      .map(({ name, id }) => (
+                        <SelectedMultiFilterButton
+                          key={id}
+                          type="button"
+                          shape="round"
+                          backgroundColor={
+                            type === '작성자' ? 'gray_2' : 'green'
+                          }
+                          color={type === '작성자' ? 'gray_8' : 'white'}
+                          onClick={() => removeMultiFilterItem(type, id)}
+                        >
+                          {name}
+                        </SelectedMultiFilterButton>
+                      ))
+                  )}
+                </SelectedMultiFilterWrapper>
+              )}
             </FilterWrapper>
             <PublicWorkbookList
               isLoading={isLoading}
@@ -297,14 +321,37 @@ const Filter = styled.div`
 `;
 
 const SelectedMultiFilterWrapper = styled.div`
-  margin-top: 0.5rem;
+  margin-top: 0.7rem;
+  margin-bottom: 0.3rem;
   white-space: nowrap;
+  overflow-x: auto;
+
+  ${({ theme }) => css`
+    ${isMobile
+      ? css`
+          ::-webkit-scrollbar {
+            display: none;
+          }
+        `
+      : css`
+          padding-bottom: 0.5rem;
+          ::-webkit-scrollbar {
+            height: 4px;
+          }
+          ::-webkit-scrollbar-thumb {
+            background-color: ${theme.color.gray_4};
+          }
+        `}
+  `}
 `;
 
-const SelectedMultiFilter = styled.div`
-  margin-bottom: 0.3rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
+const SelectedMultiFilterButton = styled(Button)`
+  flex-shrink: 0;
+  padding: 0.5rem 1rem;
+
+  &:not(:first-of-type) {
+    margin-left: 0.5rem;
+  }
 `;
 
 const FilterResetButton = styled.button`

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -23,6 +23,41 @@ import { isMobile } from '../utils';
 import PageTemplate from './PageTemplate';
 import PublicWorkbookLoadable from './PublicSearchResultLoadable';
 
+const dummyList = [
+  {
+    id: 1,
+    name: 'java',
+  },
+  {
+    id: 2,
+    name: 'javascript',
+  },
+  {
+    id: 3,
+    name: '자바',
+  },
+  {
+    id: 4,
+    name: '자스',
+  },
+  {
+    id: 5,
+    name: '자바스크립트',
+  },
+  {
+    id: 6,
+    name: 'javascriptjavascriptjavascriptjavascript',
+  },
+  {
+    id: 7,
+    name: '자스스스',
+  },
+  {
+    id: 8,
+    name: 'ㅁㄴㅇㅁㄴㅇ',
+  },
+];
+
 type MultiFilterTypes = '태그' | '작성자';
 
 interface MultiFilterData {
@@ -100,6 +135,15 @@ const PublicSearchResultPage = () => {
     searchForPublicWorkbook(initialValue);
   };
 
+  const getMultiFilterData = () => {
+    setSelectedMultiFilters((prevValue) =>
+      prevValue.map((value) => ({
+        ...value,
+        data: dummyList.map((dummy) => ({ ...dummy, isSelected: false })),
+      }))
+    );
+  };
+
   const removeMultiFilterItem = (type: MultiFilterTypes, itemId: number) => {
     setSelectedMultiFilters((prevValue) =>
       prevValue.map((multiFilterItem) => {
@@ -128,6 +172,7 @@ const PublicSearchResultPage = () => {
 
   useEffect(() => {
     setIsSearching(true);
+    getMultiFilterData();
     searchForPublicWorkbook({ keyword, type, criteria });
   }, []);
 

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -19,6 +19,7 @@ import {
 } from '../hooks';
 import { Flex } from '../styles';
 import { ValueOf } from '../types/utils';
+import { isMobile } from '../utils';
 import PageTemplate from './PageTemplate';
 import PublicWorkbookLoadable from './PublicSearchResultLoadable';
 
@@ -292,9 +293,23 @@ const Filter = styled.div`
     flex-shrink: 0;
   }
 
-  ::-webkit-scrollbar {
-    display: none;
-  }
+  ${({ theme }) => css`
+    ${isMobile
+      ? css`
+          ::-webkit-scrollbar {
+            display: none;
+          }
+        `
+      : css`
+          padding-bottom: 0.5rem;
+          ::-webkit-scrollbar {
+            height: 4px;
+          }
+          ::-webkit-scrollbar-thumb {
+            background-color: ${theme.color.gray_4};
+          }
+        `}
+  `}
 `;
 
 const SelectedMultiFilterWrapper = styled.div`

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -18,6 +18,11 @@ import {
   useRouter,
 } from '../hooks';
 import { Flex } from '../styles';
+import {
+  MultiFilter,
+  MultiFilterTypes,
+  MultiFilterValue,
+} from '../types/filter';
 import { ValueOf } from '../types/utils';
 import { isMobile } from '../utils';
 import PageTemplate from './PageTemplate';
@@ -57,20 +62,6 @@ const dummyList = [
     name: 'ㅁㄴㅇㅁㄴㅇ',
   },
 ];
-
-type MultiFilterTypes = '태그' | '작성자';
-
-interface MultiFilterValue {
-  id: number;
-  name: string;
-  isSelected: boolean;
-}
-
-interface MultiFilter {
-  id: number;
-  type: MultiFilterTypes;
-  values: MultiFilterValue[];
-}
 
 const singleFilters = [
   { id: 1, type: '최신순', criteria: SEARCH_CRITERIA.DATE },

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -9,6 +9,7 @@ import { MainHeader, Quiz, Timer } from '../components';
 import { useInterval, useQuiz } from '../hooks';
 import { quizTimeState } from '../recoil';
 import { Flex } from '../styles';
+import { isMobile } from '../utils';
 import PageTemplate from './PageTemplate';
 
 interface QuizListProps {
@@ -23,15 +24,6 @@ interface QuizItemProps {
 interface QuizIndexButtonStyleProps {
   isSelected: boolean;
 }
-
-const isMobile = () => {
-  const PC_DEVICE = ['win16', 'win32', 'win64', 'mac', 'macintel'];
-  const platform = navigator.platform;
-
-  if (!platform) return false;
-
-  return !PC_DEVICE.includes(platform.toLocaleLowerCase());
-};
 
 const QuizPage = () => {
   const {
@@ -127,7 +119,7 @@ const QuizPage = () => {
             </QuizList>
           )}
         </QuizWrapper>
-        {isMobile() ? (
+        {isMobile ? (
           <MobilePageNation>
             <TouchBar
               onTouchStart={(event) => {

--- a/frontend/src/types/filter.ts
+++ b/frontend/src/types/filter.ts
@@ -1,0 +1,13 @@
+export type MultiFilterTypes = '태그' | '작성자';
+
+export interface MultiFilterValue {
+  id: number;
+  name: string;
+  isSelected: boolean;
+}
+
+export interface MultiFilter {
+  id: number;
+  type: MultiFilterTypes;
+  values: MultiFilterValue[];
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -8,3 +8,4 @@ export {
 export { default as formatNewLine } from './formatNewLine';
 export { default as debounce } from './debounce';
 export { timeConverter } from './time';
+export { isMobile } from './mobile';

--- a/frontend/src/utils/mobile.ts
+++ b/frontend/src/utils/mobile.ts
@@ -1,7 +1,7 @@
 export const isMobile = (() => {
   const { userAgent, maxTouchPoints } = window.navigator;
 
-  const isMac = /Mac OS/i.test(userAgent);
+  const isMac = /Macintosh/i.test(userAgent);
 
   if (isMac && maxTouchPoints > 0) return true;
 

--- a/frontend/src/utils/mobile.ts
+++ b/frontend/src/utils/mobile.ts
@@ -1,0 +1,11 @@
+export const isMobile = (() => {
+  const { userAgent, maxTouchPoints } = window.navigator;
+
+  const isMac = /Mac OS/i.test(userAgent);
+
+  if (isMac && maxTouchPoints > 0) return true;
+
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobi|mobi/i.test(
+    userAgent
+  );
+})();


### PR DESCRIPTION
closes #439 

## 작업 내용
- 검색 상세 페이지에서 바텀 모달 구현
- 모달을 열 때 바디가 스크롤되던 버그 해결(document.body.style에 접근했는데, 다른 방법이 있으면 알려주세요..ㅠㅠ)
- 필터링에 스티키를 적용했고, 필터링이 많아서 2줄이 되면 자리를 많이 차지하는 것 같아서 횡스크롤이 가능하게 구현했습니다.
횡스크롤을 할 때 스크롤바를 없앴는데, 데스크탑일 때 스크롤바가 없으면 혼란을 줄 수 있을 것 같아서 데스크탑인 경우에는 스크롤바를 추가해주었습니다. (isMobile을 사용했습니다.) 사실 데스크탑일 때 그만큼 width를 줄일 사람은 없을 것 같지만 혹시 모르는 상황에 대비하기 위해서 이렇게 구현했습니다.
- isMobile을 즉시실행함수로 실행해서 함수가 아닌 값으로 변경했습니다. 이유는 isMobile은 앱 처음 진입할 때만 검사하면 이후에 바뀌지 않는다고 생각했기 때문입니다. 핸드폰으로 보다가 갑자기 컴퓨터로 바뀔 수는 없다고 생각했어요. 그리고 isMobile에서 로직을 많이 변경했는데, 기존에 사용하던 navigator.platform은 deprecated되었다고 해요... [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform) 그래서 알아보다가 navigator.userAgent가 있었고, 이건 접속한 단말기의 환경을 알려주는 것이라고 해요. 근데 여기에서 또 문제가 있었는데 아이패드가 데스크탑화 한다고 2019년부터 밀어붙이다가 정말로 최신 아이패드를 조회해보면 환경이 IPad가 아니라 Macintosh, Mac OS라고 나오고 있어요. 데스크탑이랑 구분할 수가 없게 되었어요 ㅠㅠ(구글은 iPad라고 나오는데 사파리에서는 Macintosh라고 나오네요... 하 나쁜 사파리,,, 애플,,,) 
그래서 차이가 나는 부분인 Macintosh로 비교를 하도록 변경했어요. Macintosh면 태블릿일 수도 있고 맥북일 수도 있고 맥일 수도 있기 때문에 이제 다시 터치 여부로 판단하기 위해서 navigator.maxTouchPoints로 비교를 했어요. 1 이상이면 터치가 되는 것으로 터치가 된다면 태블릿으로 볼 수 있을 것 같아서요! 다른 방법이 있으면 제시해주셔도 좋아요😍😍
## 주의 사항
- 기능은 하지 않았습니다.