### PR TITLE
S05 - 검색 페이지에서 추천 검색어 기능을 구현한다

### DIFF
--- a/frontend/src/contexts/FormProvider.tsx
+++ b/frontend/src/contexts/FormProvider.tsx
@@ -63,6 +63,8 @@ const FormProvider = ({
       await validator?.(value);
       setErrorMessages({ ...errorMessages, [key]: null });
     } catch (error) {
+      if (!(error instanceof Error)) return;
+
       console.error(error);
       setErrorMessages({ ...errorMessages, [key]: error.message });
     }

--- a/frontend/src/hooks/useErrorHandler.ts
+++ b/frontend/src/hooks/useErrorHandler.ts
@@ -8,7 +8,9 @@ const useErrorHandler = () => {
   const { routeLogin } = useRouter();
   const showSnackbar = useSnackbar();
 
-  const handler = (error: AxiosError | Error) => {
+  const handler = (error: AxiosError | Error | unknown) => {
+    if (!(error instanceof Error)) return;
+
     console.error(error.message);
 
     if (!axios.isAxiosError(error)) return;

--- a/frontend/src/hooks/useRouter.ts
+++ b/frontend/src/hooks/useRouter.ts
@@ -60,7 +60,7 @@ const useRouter = () => {
     keyword = '',
     size = 20,
   }: PublicSearchQuery = {}) =>
-    history.replace({
+    history.push({
       pathname: ROUTE.PUBLIC_SEARCH_RESULT.PATH,
       search: `?type=${type}&keyword=${keyword}&criteria=${criteria}&size=${size}`,
     });

--- a/frontend/src/hooks/useRouter.ts
+++ b/frontend/src/hooks/useRouter.ts
@@ -59,8 +59,9 @@ const useRouter = () => {
     type = 'name',
     keyword = '',
     size = 20,
+    method = 'replace',
   }: PublicSearchQuery = {}) =>
-    history.push({
+    history[method]({
       pathname: ROUTE.PUBLIC_SEARCH_RESULT.PATH,
       search: `?type=${type}&keyword=${keyword}&criteria=${criteria}&size=${size}`,
     });

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import axios from 'axios';
 import React, { useState } from 'react';
 
 import { postUserNameCheckAsync } from '../api';
@@ -26,11 +27,15 @@ const validateUserName = async (value: string) => {
   try {
     await postUserNameCheckAsync(value);
   } catch (error) {
-    if (error.response.data.code === 'U003') {
-      throw new Error(ERROR_MESSAGE.U003);
-    }
+    if (!(error instanceof Error)) return;
 
     console.error(error);
+
+    if (!axios.isAxiosError(error)) return;
+
+    if (error.response?.data.code === 'U003') {
+      throw new Error(ERROR_MESSAGE.U003);
+    }
   }
 
   if (value.length > USER_NAME_MAXIMUM_LENGTH) {
@@ -79,6 +84,8 @@ const ProfilePage = () => {
       updateProfileUrl(file);
       currentTarget.value = '';
     } catch (error) {
+      if (!(error instanceof Error)) return;
+
       showSnackbar({ message: error.message });
     }
   };

--- a/frontend/src/pages/PublicSearchPage.tsx
+++ b/frontend/src/pages/PublicSearchPage.tsx
@@ -33,7 +33,7 @@ const PublicSearchPage = () => {
     SearchKeywordResponse[]
   >([]);
 
-  const [scaleX, setScaleX] = useState(1);
+  const [searchBarWidth, setSearchBarWidth] = useState(1);
 
   const { routePublicCards, routePublicSearchResultQuery } = useRouter();
   const errorHandler = useErrorHandler();
@@ -42,18 +42,29 @@ const PublicSearchPage = () => {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    let mounted = true;
+
     const getPublicWorkbooks = async () => {
       try {
         const newPublicWorkbooks = await getPublicWorkbookAsync();
-        setPublicWorkbooks(newPublicWorkbooks);
+
+        if (!mounted) return;
+
         setIsLoading(false);
+        setPublicWorkbooks(newPublicWorkbooks);
       } catch (error) {
+        if (!mounted) return;
+
         errorHandler(error);
         setIsLoading(false);
       }
     };
 
     getPublicWorkbooks();
+
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   useEffect(() => {
@@ -96,20 +107,20 @@ const PublicSearchPage = () => {
   }, [searchKeyword]);
 
   useEffect(() => {
-    const calculateScaleX = () => {
+    const calculateSearchBarWidth = () => {
       if (!stickyTriggerRef.current) return;
 
-      setScaleX(
+      setSearchBarWidth(
         (stickyTriggerRef.current.offsetWidth + 40) /
           stickyTriggerRef.current.offsetWidth
       );
     };
 
-    calculateScaleX();
+    calculateSearchBarWidth();
 
-    window.addEventListener('resize', calculateScaleX);
+    window.addEventListener('resize', calculateSearchBarWidth);
 
-    return () => window.addEventListener('resize', calculateScaleX);
+    return () => window.removeEventListener('resize', calculateSearchBarWidth);
   }, [stickyTriggerRef.current]);
 
   if (isLoading) return <PublicSearchLoadable />;
@@ -124,7 +135,7 @@ const PublicSearchPage = () => {
           role="search"
           isSticky={isSticky}
           isFocus={isFocus}
-          scaleX={scaleX}
+          scaleX={searchBarWidth}
           onFocus={() => setIsFocus(true)}
           onBlur={() => setIsFocus(isMobile ? true : false)}
           onSubmit={(event) => {


### PR DESCRIPTION
closes #436 

## 작업 내용

- 추천 검색어
- 검색 기능
- 에러 타입 가드 처리

## 주의 사항

- `onBlur` 시 인풋에 값이 있다면 `isFocus` 유지 -> 인풋에 값이 있으면 검색 버튼을 눌렀을 때, 검색이 되는 상태인데 비활성화처럼 보이는 것이 어색한 것 같아 수정했습니다!
- `<RecommendedKeyword />`에 `onTouchStart` 바인딩 -> 모바일 화면에서 키보드 자판 때문에 자동완성 일부가 가려지고 있어 해당 영역을 터치했을 때 자판이 내려가게 blur를 시켜주었습니다. (m.naver 참고)
- Searchbar z-index 고정 -> 자동완성 z-index까지 고려해서 고정하는 게 낫겠다 생각했습니다!
- routePublicSearchResultQuery history.push 로 변경 -> 페이지가 나누어져 뒤로가기를 했을 때 검색창으로 돌아오는 게 자연스러울 것 같아요ㅎㅎ