### PR TITLE
W02 - 다양한 문제집 api 응답에 heartCount와 tags를 추가한다. 

### DIFF
--- a/backend/src/main/java/botobo/core/application/WorkbookService.java
+++ b/backend/src/main/java/botobo/core/application/WorkbookService.java
@@ -158,6 +158,6 @@ public class WorkbookService extends AbstractUserService {
 
     public List<WorkbookResponse> findPublicWorkbooks() {
         List<Workbook> workbooks = workbookRepository.findRandomPublicWorkbooks();
-        return WorkbookResponse.simpleListOf(workbooks);
+        return WorkbookResponse.openedListOf(workbooks);
     }
 }

--- a/backend/src/main/java/botobo/core/dto/workbook/WorkbookResponse.java
+++ b/backend/src/main/java/botobo/core/dto/workbook/WorkbookResponse.java
@@ -48,21 +48,6 @@ public class WorkbookResponse {
                 .build();
     }
 
-    private static WorkbookResponse simpleOf(Workbook workbook) {
-        return WorkbookResponse.builder()
-                .id(workbook.getId())
-                .name(workbook.getName())
-                .cardCount(workbook.cardCount())
-                .author(workbook.author())
-                .build();
-    }
-
-    public static List<WorkbookResponse> simpleListOf(List<Workbook> workbooks) {
-        return workbooks.stream()
-                .map(WorkbookResponse::simpleOf)
-                .collect(Collectors.toList());
-    }
-
     public static List<WorkbookResponse> authorListOf(List<Workbook> workbooks) {
         return workbooks.stream()
                 .map(WorkbookResponse::authorOf)

--- a/backend/src/test/java/botobo/core/documentation/SearchDocumentationTest.java
+++ b/backend/src/test/java/botobo/core/documentation/SearchDocumentationTest.java
@@ -33,6 +33,7 @@ public class SearchDocumentationTest extends DocumentationTest {
                         .id(2L)
                         .name("피케이의 java 문제집")
                         .cardCount(15)
+                        .heartCount(5)
                         .author("pkeugine")
                         .tags(List.of(
                                 TagResponse.builder().id(1L).name("java").build(),
@@ -43,6 +44,7 @@ public class SearchDocumentationTest extends DocumentationTest {
                         .id(1L)
                         .name("피케이의 javascript 문제집")
                         .cardCount(15)
+                        .heartCount(3)
                         .author("pkeugine")
                         .tags(List.of(
                                 TagResponse.builder().id(3L).name("javascript").build(),

--- a/backend/src/test/java/botobo/core/documentation/WorkbookDocumentationTest.java
+++ b/backend/src/test/java/botobo/core/documentation/WorkbookDocumentationTest.java
@@ -354,13 +354,23 @@ public class WorkbookDocumentationTest extends DocumentationTest {
                         .id(1L)
                         .name("피케이의 Network 정복 모음집")
                         .cardCount(8)
+                        .heartCount(10)
                         .author("피케이")
+                        .tags(List.of(
+                                TagResponse.builder().id(1L).name("network").build(),
+                                TagResponse.builder().id(2L).name("네트워크").build()
+                        ))
                         .build(),
                 WorkbookResponse.builder()
                         .id(2L)
                         .name("오즈의 Network 정복 최종판")
                         .cardCount(20)
+                        .heartCount(5)
                         .author("오즈")
+                        .tags(List.of(
+                                TagResponse.builder().id(1L).name("network").build(),
+                                TagResponse.builder().id(3L).name("cs지식").build()
+                        ))
                         .build()
         );
     }


### PR DESCRIPTION
closes #495 

## 작업 내용
- 다양한 문제집 가져오는 api 응답 반환 메서드를 변경했습니다.
- 기존에 사용되고 있던 메서드는 삭제했습니다.
- 이에 맞게 문서 테스트를 수정했습니다.

## 주의 사항
- 없음