### PR TITLE
F44 - 전체적인 UI 개선

### DIFF
--- a/frontend/src/components/PublicQnACard.tsx
+++ b/frontend/src/components/PublicQnACard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
 
+import { Flex } from '../styles';
 import { CardResponse } from '../types';
 import CardTemplate from './CardTemplate';
 
@@ -14,13 +15,23 @@ interface Props extends PickedCardResponse {
 
 const PublicQnACard = ({ question, answer, isChecked, onClick }: Props) => (
   <CardTemplate isChecked={isChecked} onClick={onClick}>
-    <Question>Q. {question}</Question>
-    <Answer>A. {answer}</Answer>
+    <Question>
+      <span>Q.</span> {question}
+    </Question>
+    <Answer>
+      <span>A.</span> {answer}
+    </Answer>
   </CardTemplate>
 );
 
 const Question = styled.div`
+  ${Flex()};
   padding: 1rem 0;
+  line-height: 1.5;
+
+  & > span {
+    margin-right: 0.3rem;
+  }
 
   ${({ theme }) => css`
     border-bottom: 2px solid ${theme.color.gray_3};
@@ -28,8 +39,14 @@ const Question = styled.div`
 `;
 
 const Answer = styled.div`
+  ${Flex()};
   padding-top: 1.5rem;
   padding-bottom: 1rem;
+  line-height: 1.5;
+
+  & > span {
+    margin-right: 0.3rem;
+  }
 `;
 
 export default PublicQnACard;

--- a/frontend/src/components/QnACard.tsx
+++ b/frontend/src/components/QnACard.tsx
@@ -63,8 +63,12 @@ const QnACard = ({
           {isBookmark ? <FillStarIcon /> : <EmptyStarIcon />}
         </BookmarkButton>
       </Header>
-      <Question>Q. {cardInfo.question}</Question>
-      <Answer>A. {cardInfo.answer}</Answer>
+      <Question>
+        <span>Q.</span> {cardInfo.question}
+      </Question>
+      <Answer>
+        <span>A.</span> {cardInfo.answer}
+      </Answer>
     </CardTemplate>
   );
 };
@@ -89,7 +93,13 @@ const BookmarkButton = styled.button`
 `;
 
 const Question = styled.div`
+  ${Flex()};
   padding-bottom: 1rem;
+  line-height: 1.5;
+
+  & > span {
+    margin-right: 0.3rem;
+  }
 
   ${({ theme }) => css`
     border-bottom: 2px solid ${theme.color.gray_3};
@@ -97,7 +107,13 @@ const Question = styled.div`
 `;
 
 const Answer = styled.div`
+  ${Flex()};
   padding-top: 1.5rem;
+  line-height: 1.5;
+
+  & > span {
+    margin-right: 0.3rem;
+  }
 `;
 
 export default QnACard;

--- a/frontend/src/components/Quiz.tsx
+++ b/frontend/src/components/Quiz.tsx
@@ -40,17 +40,25 @@ const Quiz = ({
               <EncounterCount>풀어본 횟수: {encounterCount}</EncounterCount>
             )}
           </TopContent>
-          <Text>
-            <span>Q. {question}</span>
-          </Text>
+          <TextWrapper>
+            <Text>
+              <TextCenter>
+                <span>Q.</span> {question}
+              </TextCenter>
+            </Text>
+          </TextWrapper>
         </Question>
         <Answer>
           <TopContent>
             <WorkbookName>{workbookName}</WorkbookName>
           </TopContent>
-          <Text>
-            <span>A. {answer}</span>
-          </Text>
+          <TextWrapper>
+            <Text>
+              <TextCenter>
+                <span>A.</span> {answer}
+              </TextCenter>
+            </Text>
+          </TextWrapper>
         </Answer>
       </Card>
     </Container>
@@ -58,9 +66,9 @@ const Quiz = ({
 };
 
 const Container = styled.div`
-  height: 12.5rem;
+  height: 35vh;
   width: 100%;
-  perspective: 50rem;
+  perspective: 100rem;
 `;
 
 const Card = styled.div<CardStyleProps>`
@@ -84,11 +92,13 @@ const Card = styled.div<CardStyleProps>`
     width: 100%;
     height: 100%;
     backface-visibility: hidden;
+    overflow-y: auto;
 
     ${({ theme }) =>
       css`
         box-shadow: ${theme.boxShadow.card};
         border-radius: ${theme.borderRadius.square};
+        background-color: ${theme.color.white};
       `}
   }
 `;
@@ -119,33 +129,31 @@ const EncounterCount = styled.span`
 
 const Question = styled.div`
   transform: rotateX(0deg);
-  overflow-y: auto;
-
-  ${({ theme }) => css`
-    background-color: ${theme.color.white};
-  `}
 `;
 
 const Answer = styled.div`
   transform: rotateX(180deg);
-  overflow-y: auto;
+`;
 
-  ${({ theme }) => css`
-    background-color: ${theme.color.white};
-  `}
+const TextWrapper = styled.div`
+  overflow-y: auto;
+  height: 100%;
+  line-height: calc(35vh - 3.5rem);
+
+  ${scrollBarStyle};
 `;
 
 const Text = styled.div`
-  overflow-y: auto;
-  height: 9rem;
-  line-height: 9rem;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1.5;
+`;
 
-  ${scrollBarStyle};
+const TextCenter = styled.div`
+  ${Flex()};
 
   & > span {
-    display: inline-block;
-    vertical-align: middle;
-    line-height: 1.4rem;
+    margin-right: 0.3rem;
   }
 `;
 

--- a/frontend/src/components/QuizResult.tsx
+++ b/frontend/src/components/QuizResult.tsx
@@ -23,7 +23,9 @@ const QuizResult = ({
       <WorkbookName>{workbookName}</WorkbookName>
       <EncounterCount>풀어본 횟수: {encounterCount}</EncounterCount>
     </TopContent>
-    <Question>Q. {question}</Question>
+    <Question>
+      <span>Q.</span> {question}
+    </Question>
   </CardTemplate>
 );
 
@@ -47,7 +49,13 @@ const EncounterCount = styled.span`
 `;
 
 const Question = styled.div`
+  ${Flex()};
   margin-bottom: 1rem;
+  line-height: 1.5;
+
+  & > span {
+    margin-right: 0.3rem;
+  }
 `;
 
 export default QuizResult;


### PR DESCRIPTION
closes #485 

## 작업 내용
- 퀴즈 페이지의 카드 크기 조정(기기에 따라 커지도록 35vh)
- A.이나 Q. 과 질문, 정답 텍스트를 분리해서 Q. , A. 뒤에 텍스트가 들어가도록 설정
- 질문과 정답의 line-height를 1.5로 설정해서 가독성 증가
## 주의 사항
- Quiz 컴포넌트에 하드코딩이 되어 있습니다. 질문, 정답 수직 정렬을 하기 위해 이전에는 height와 line-height를 같게 9rem으로 맞춰줬었지만 지금은 기기에 따라 카드 크기를 다르게 해서 35vh로 설정했고, height는 100%가 설정되지만 line-height는 되지 않기 때문에 하드코딩이 되어 있는 상태입니다. 어떻게 잘 고칠 방법이 있을까요?
![image](https://user-images.githubusercontent.com/64782636/133202831-49484b23-3b7a-4250-a7d3-51ef5c59d140.png)
- 질문과 정답에서 Q. , A.과 텍스트를 분리하기 위해 flex를 사용했습니다. 하나의 컴포넌트에서 사용하고 있는 것이 아니라서 각각의 컴포넌트에 일일이 스타일을 부여했는데 괜찮을까요? 
![image](https://user-images.githubusercontent.com/64782636/133203087-6c8316eb-6cef-4634-99ef-e03e742f2955.png)
