### PR TITLE
C14 - 카드 상세 페이지에서 태그를 눌렀을 때 태그 검색되는 기능 구현

### DIFF
--- a/frontend/src/pages/PublicCardsPage.tsx
+++ b/frontend/src/pages/PublicCardsPage.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { Link } from 'react-router-dom';
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { getQuizzesAsync } from '../api';
 import EmptyHeartIcon from '../assets/heart-regular.svg';
@@ -16,7 +17,12 @@ import {
 } from '../components';
 import { QUIZ_MODE, ROUTE, theme } from '../constants';
 import { useModal, usePublicCard, useRouter, useWorkbook } from '../hooks';
-import { quizModeState, quizState, userState } from '../recoil';
+import {
+  publicSearchResultState,
+  quizModeState,
+  quizState,
+  userState,
+} from '../recoil';
 import { Flex } from '../styles';
 import { debounce } from '../utils';
 import PageTemplate from './PageTemplate';
@@ -26,6 +32,8 @@ const PublicCardsPage = () => {
   const setQuiz = useSetRecoilState(quizState);
   const setQuizMode = useSetRecoilState(quizModeState);
   const isLogin = useRecoilValue(userState) ? true : false;
+
+  const resetSearchResult = useResetRecoilState(publicSearchResultState);
 
   const { workbooks } = useWorkbook();
   const {
@@ -45,9 +53,6 @@ const PublicCardsPage = () => {
     toggleHeart,
     showSnackbar,
   } = usePublicCard();
-
-  const { routePublicSearchResultQuery } = useRouter();
-
   const { openModal, closeModal } = useModal();
   const { routeQuiz } = useRouter();
 
@@ -121,13 +126,8 @@ const PublicCardsPage = () => {
             {tags.map(({ id, name }) => (
               <TagWrapper key={id}>
                 <Tag
-                  type="button"
-                  onClick={() =>
-                    routePublicSearchResultQuery({
-                      keyword: name,
-                      method: 'push',
-                    })
-                  }
+                  to={`${ROUTE.PUBLIC_SEARCH_RESULT.PATH}?keyword=${name}`}
+                  onClick={resetSearchResult}
                 >
                   <span>#</span>
                   {name}
@@ -232,17 +232,20 @@ const CardCount = styled.div`
 `;
 
 const TagWrapper = styled.li`
-  display: inline-block;
+  display: inline;
   word-break: break-all;
 `;
 
-const Tag = styled.button`
+const Tag = styled(Link)`
   margin-right: 0.5rem;
-  text-align: left;
+  line-height: 1.5;
 
   ${({ theme }) => css`
     color: ${theme.color.blue};
-    font-size: ${theme.fontSize.default};
+
+    &:visited {
+      color: ${theme.color.blue};
+    }
   `};
 
   & > span {

--- a/frontend/src/pages/PublicSearchResultPage.tsx
+++ b/frontend/src/pages/PublicSearchResultPage.tsx
@@ -197,7 +197,7 @@ const PublicSearchResultPage = () => {
 };
 
 const StyledPageTemplate = styled(PageTemplate)`
-  padding-top: 1rem;
+  padding-top: 2rem;
 `;
 
 const NoSearchResult = styled.div`


### PR DESCRIPTION
closes #486 

## 작업 내용
- 카드 상세 페이지에서 태그를 눌렀을 때 태그 검색되는 기능 구현했습니다. Link태그로 사용했고, 스타일을 조금 변경했습니다. 기존에는 li 태그가 inline-block이였어서 태그가 뭉터기로 움직였었는데, inline으로 해서 한글자씩 움직이게 하는 것이 더 좋아보여서 바꿨습니다. 어떤가요?

기존
데스크탑
![image](https://user-images.githubusercontent.com/64782636/133493140-61c8c922-1313-49b7-97d4-1e6090907ef6.png)
모바일
![image](https://user-images.githubusercontent.com/64782636/133493233-b59adab0-7be6-4c60-89ec-6acf17ee0388.png)

변경
데스크탑
 ![image](https://user-images.githubusercontent.com/64782636/133492791-d136401e-d8ec-4314-b207-7e0fd3afd598.png)
모바일 
![image](https://user-images.githubusercontent.com/64782636/133493206-a9e6de70-6678-423d-b8ef-21a77bc116fc.png)

- 검색 상세 결과 페이지에서 top이 너무 조금 떨어져 있는 것 같아서 1rem에서 2rem으로 변경했습니다.
## 주의 사항
- 없음