### PR TITLE
W03 - 문제집 상세보기 페이지에 하트 수와 태그를 포함한다 

### DIFF
--- a/backend/src/main/java/botobo/core/dto/workbook/WorkbookCardResponse.java
+++ b/backend/src/main/java/botobo/core/dto/workbook/WorkbookCardResponse.java
@@ -32,9 +32,12 @@ public class WorkbookCardResponse {
 
     public static WorkbookCardResponse ofUserWorkbook(Workbook workbook) {
         List<CardResponse> cardResponses = CardResponse.listOf(workbook.getCards());
+        List<TagResponse> tagResponses = TagResponse.listOf(workbook.tags());
         return WorkbookCardResponse.builder()
                 .workbookId(workbook.getId())
                 .workbookName(workbook.getName())
+                .heartCount(workbook.heartCount())
+                .tags(tagResponses)
                 .cards(cardResponses)
                 .build();
     }

--- a/backend/src/test/java/botobo/core/acceptance/workbook/WorkbookAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/acceptance/workbook/WorkbookAcceptanceTest.java
@@ -32,7 +32,7 @@ import static botobo.core.utils.TestUtils.stringGenerator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Workbook 인수 테스트")
-public class WorkbookAcceptanceTest extends DomainAcceptanceTest {
+class WorkbookAcceptanceTest extends DomainAcceptanceTest {
 
     @Test
     @DisplayName("유저가 문제집 추가 - 성공")
@@ -59,7 +59,7 @@ public class WorkbookAcceptanceTest extends DomainAcceptanceTest {
         assertThat(workbookResponse.getTags()).hasSize(1);
         assertThat(workbookResponse.getTags().get(0).getId()).isNotZero();
         assertThat(workbookResponse.getTags().get(0).getName()).isEqualTo("자바");
-        assertThat(workbookResponse.getHeartCount()).isEqualTo(0);
+        assertThat(workbookResponse.getHeartCount()).isZero();
     }
 
     @Test
@@ -268,7 +268,7 @@ public class WorkbookAcceptanceTest extends DomainAcceptanceTest {
         // then
         List<WorkbookResponse> publicWorkbookResponses = response.convertBodyToList(WorkbookResponse.class);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(publicWorkbookResponses).hasSize(0);
+        assertThat(publicWorkbookResponses).isEmpty();
     }
 
     @Test
@@ -290,7 +290,7 @@ public class WorkbookAcceptanceTest extends DomainAcceptanceTest {
         // then
         List<WorkbookResponse> publicWorkbookResponses = response.convertBodyToList(WorkbookResponse.class);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(publicWorkbookResponses).hasSize(0);
+        assertThat(publicWorkbookResponses).isEmpty();
     }
 
     @Test
@@ -348,6 +348,8 @@ public class WorkbookAcceptanceTest extends DomainAcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
         assertThat(workbookCardResponse.getWorkbookName()).isEqualTo(workbookResponse.getName());
         assertThat(workbookCardResponse.getCards()).hasSize(3);
+        assertThat(workbookCardResponse.getTags()).hasSize(1);
+        assertThat(workbookCardResponse.getHeartCount()).isZero();
     }
 
     @Test

--- a/backend/src/test/java/botobo/core/documentation/WorkbookDocumentationTest.java
+++ b/backend/src/test/java/botobo/core/documentation/WorkbookDocumentationTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("문제집 문서화 테스트")
 @WebMvcTest(WorkbookController.class)
-public class WorkbookDocumentationTest extends DocumentationTest {
+class WorkbookDocumentationTest extends DocumentationTest {
 
     @MockBean
     private WorkbookService workbookService;
@@ -332,6 +332,8 @@ public class WorkbookDocumentationTest extends DocumentationTest {
         return WorkbookCardResponse.builder()
                 .workbookId(1L)
                 .workbookName("Java")
+                .heartCount(10)
+                .tags(generateTagResponses())
                 .cards(generateCardResponses())
                 .build();
     }


### PR DESCRIPTION
closes #539 

## 작업 내용
엄청 간단한 dto 수정 작업입니다.
문제집 상세보기 페이지에서 하트 수와 태그를 볼 수 있도록 했어요.
그리고 하는 김에 관련 class 에서 SonarLint가 잡아주는 경고들 잡아줬습니다!

## 주의 사항
너무 간단해서 리뷰 할 게 없을 것 같은게 주의사항