### PR TITLE
fix/U01, T01 - 필터에서 조회되는 유저와 태그가 문제집의 카드가 0개일 때는 조회되지 않도록 수정한다. 

### DIFF
--- a/backend/src/main/java/botobo/core/application/AbstractUserService.java
+++ b/backend/src/main/java/botobo/core/application/AbstractUserService.java
@@ -8,7 +8,7 @@ import botobo.core.exception.user.UserNotFoundException;
 public abstract class AbstractUserService {
     protected final UserRepository userRepository;
 
-    public AbstractUserService(UserRepository userRepository) {
+    protected AbstractUserService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 

--- a/backend/src/main/java/botobo/core/application/TagService.java
+++ b/backend/src/main/java/botobo/core/application/TagService.java
@@ -1,20 +1,17 @@
 package botobo.core.application;
 
 import botobo.core.domain.tag.Tag;
+import botobo.core.domain.tag.TagFilterRepository;
 import botobo.core.domain.tag.TagName;
 import botobo.core.domain.tag.TagRepository;
 import botobo.core.domain.tag.Tags;
-import botobo.core.domain.workbooktag.WorkbookTag;
 import botobo.core.dto.tag.FilterCriteria;
 import botobo.core.dto.tag.TagRequest;
 import botobo.core.dto.tag.TagResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -22,9 +19,11 @@ import java.util.stream.Collectors;
 public class TagService {
 
     private final TagRepository tagRepository;
+    private final TagFilterRepository tagFilterRepository;
 
-    public TagService(TagRepository tagRepository) {
+    public TagService(TagRepository tagRepository, TagFilterRepository tagFilterRepository) {
         this.tagRepository = tagRepository;
+        this.tagFilterRepository = tagFilterRepository;
     }
 
     public Tags convertTags(List<TagRequest> tagRequests) {
@@ -41,22 +40,10 @@ public class TagService {
         if (filterCriteria.isEmpty()) {
             return TagResponse.listOf(Tags.empty());
         }
-        List<Tag> allTags = tagRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook());
+        List<Tag> allTags = tagFilterRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook());
 
-        Set<Tag> tagSet = new LinkedHashSet<>();
-        for (Tag tag : allTags) {
-            final List<WorkbookTag> workbookTags = tag.getWorkbookTags();
-            filterTagHavingNonZeroCards(tagSet, tag, workbookTags);
-        }
-
-        Tags tags = Tags.of(new ArrayList<>(tagSet));
+        Tags tags = Tags.of(allTags);
         return TagResponse.listOf(tags);
     }
 
-    private void filterTagHavingNonZeroCards(Set<Tag> tagSet, Tag tag, List<WorkbookTag> workbookTags) {
-        workbookTags.stream()
-                .filter(workbookTag -> workbookTag.getWorkbook().cardCount() > 0)
-                .map(workbookTag -> tag)
-                .forEach(tagSet::add);
-    }
 }

--- a/backend/src/main/java/botobo/core/application/TagService.java
+++ b/backend/src/main/java/botobo/core/application/TagService.java
@@ -4,13 +4,17 @@ import botobo.core.domain.tag.Tag;
 import botobo.core.domain.tag.TagName;
 import botobo.core.domain.tag.TagRepository;
 import botobo.core.domain.tag.Tags;
+import botobo.core.domain.workbooktag.WorkbookTag;
 import botobo.core.dto.tag.FilterCriteria;
 import botobo.core.dto.tag.TagRequest;
 import botobo.core.dto.tag.TagResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -37,7 +41,22 @@ public class TagService {
         if (filterCriteria.isEmpty()) {
             return TagResponse.listOf(Tags.empty());
         }
-        Tags tags = Tags.of(tagRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook()));
+        List<Tag> allTags = tagRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook());
+
+        Set<Tag> tagSet = new LinkedHashSet<>();
+        for (Tag tag : allTags) {
+            final List<WorkbookTag> workbookTags = tag.getWorkbookTags();
+            filterTagHavingNonZeroCards(tagSet, tag, workbookTags);
+        }
+
+        Tags tags = Tags.of(new ArrayList<>(tagSet));
         return TagResponse.listOf(tags);
+    }
+
+    private void filterTagHavingNonZeroCards(Set<Tag> tagSet, Tag tag, List<WorkbookTag> workbookTags) {
+        workbookTags.stream()
+                .filter(workbookTag -> workbookTag.getWorkbook().cardCount() > 0)
+                .map(workbookTag -> tag)
+                .forEach(tagSet::add);
     }
 }

--- a/backend/src/main/java/botobo/core/application/UserService.java
+++ b/backend/src/main/java/botobo/core/application/UserService.java
@@ -3,6 +3,7 @@ package botobo.core.application;
 import botobo.core.domain.user.AppUser;
 import botobo.core.domain.user.User;
 import botobo.core.domain.user.UserRepository;
+import botobo.core.domain.workbook.Workbook;
 import botobo.core.dto.tag.FilterCriteria;
 import botobo.core.dto.user.ProfileResponse;
 import botobo.core.dto.user.UserFilterResponse;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -75,7 +77,20 @@ public class UserService extends AbstractUserService {
         if (filterCriteria.isEmpty()) {
             return UserFilterResponse.listOf(emptyList());
         }
-        List<User> users = userRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook());
+        List<User> allUsers = userRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook());
+
+        List<User> users = new ArrayList<>();
+        for (User user : allUsers) {
+            List<Workbook> userWorkbooks = user.getWorkbooks();
+            filterUserHavingNonZeroCards(users, user, userWorkbooks);
+        }
         return UserFilterResponse.listOf(users);
+    }
+
+    private void filterUserHavingNonZeroCards(List<User> users, User user, List<Workbook> userWorkbooks) {
+        userWorkbooks.stream()
+                .filter(workbook -> workbook.cardCount() > 0)
+                .map(workbook -> user)
+                .forEach(users::add);
     }
 }

--- a/backend/src/main/java/botobo/core/application/UserService.java
+++ b/backend/src/main/java/botobo/core/application/UserService.java
@@ -2,8 +2,8 @@ package botobo.core.application;
 
 import botobo.core.domain.user.AppUser;
 import botobo.core.domain.user.User;
+import botobo.core.domain.user.UserFilterRepository;
 import botobo.core.domain.user.UserRepository;
-import botobo.core.domain.workbook.Workbook;
 import botobo.core.dto.tag.FilterCriteria;
 import botobo.core.dto.user.ProfileResponse;
 import botobo.core.dto.user.UserFilterResponse;
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -26,10 +25,14 @@ import static java.util.Collections.emptyList;
 @Transactional(readOnly = true)
 public class UserService extends AbstractUserService {
 
+    private final UserFilterRepository userFilterRepository;
     private final FileUploader fileUploader;
 
-    public UserService(UserRepository userRepository, FileUploader fileUploader) {
+    public UserService(UserRepository userRepository,
+                       UserFilterRepository userFilterRepository,
+                       FileUploader fileUploader) {
         super(userRepository);
+        this.userFilterRepository = userFilterRepository;
         this.fileUploader = fileUploader;
     }
 
@@ -77,20 +80,7 @@ public class UserService extends AbstractUserService {
         if (filterCriteria.isEmpty()) {
             return UserFilterResponse.listOf(emptyList());
         }
-        List<User> allUsers = userRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook());
-
-        List<User> users = new ArrayList<>();
-        for (User user : allUsers) {
-            List<Workbook> userWorkbooks = user.getWorkbooks();
-            filterUserHavingNonZeroCards(users, user, userWorkbooks);
-        }
+        List<User> users = userFilterRepository.findAllByContainsWorkbookName(filterCriteria.getWorkbook());
         return UserFilterResponse.listOf(users);
-    }
-
-    private void filterUserHavingNonZeroCards(List<User> users, User user, List<Workbook> userWorkbooks) {
-        userWorkbooks.stream()
-                .filter(workbook -> workbook.cardCount() > 0)
-                .map(workbook -> user)
-                .forEach(users::add);
     }
 }

--- a/backend/src/main/java/botobo/core/domain/tag/TagFilterRepository.java
+++ b/backend/src/main/java/botobo/core/domain/tag/TagFilterRepository.java
@@ -30,7 +30,7 @@ public class TagFilterRepository {
                 .innerJoin(tag.workbookTags, workbookTag).fetchJoin()
                 .innerJoin(workbookTag.workbook, workbook)
                 .innerJoin(workbook.cards.cards, card)
-                .where(containWorkbookName(workbookName), 
+                .where(containWorkbookName(workbookName),
                         openedTrue())
                 .fetch();
     }

--- a/backend/src/main/java/botobo/core/domain/tag/TagFilterRepository.java
+++ b/backend/src/main/java/botobo/core/domain/tag/TagFilterRepository.java
@@ -1,15 +1,16 @@
 package botobo.core.domain.tag;
 
 
-import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
+import static botobo.core.domain.card.QCard.card;
 import static botobo.core.domain.tag.QTag.tag;
 import static botobo.core.domain.workbook.QWorkbook.workbook;
 import static botobo.core.domain.workbooktag.QWorkbookTag.workbookTag;
@@ -20,24 +21,29 @@ public class TagFilterRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<Tag> findAllByContainsWorkbookName(@Param("workbookName") String workbookName) {
-        QueryResults<Tag> results = jpaQueryFactory.selectFrom(tag)
+    public List<Tag> findAllByContainsWorkbookName(String workbookName) {
+        if (Objects.isNull(workbookName)) {
+            return Collections.emptyList();
+        }
+        return jpaQueryFactory.selectFrom(tag)
+                .distinct()
                 .innerJoin(tag.workbookTags, workbookTag).fetchJoin()
                 .innerJoin(workbookTag.workbook, workbook)
-                .where(containWorkbookName(workbookName))
-                .fetchResults();
-        return results.getResults();
+                .innerJoin(workbook.cards.cards, card)
+                .where(containWorkbookName(workbookName), 
+                        openedTrue())
+                .fetch();
     }
 
     private BooleanExpression containWorkbookName(String workbookName) {
-        if (workbookName == null) {
-            return null;
-        }
         return workbook
                 .name
                 .lower()
                 .contains(workbookName.toLowerCase());
     }
 
+    private BooleanExpression openedTrue() {
+        return workbook.opened.isTrue();
+    }
 
 }

--- a/backend/src/main/java/botobo/core/domain/tag/TagFilterRepository.java
+++ b/backend/src/main/java/botobo/core/domain/tag/TagFilterRepository.java
@@ -1,0 +1,43 @@
+package botobo.core.domain.tag;
+
+
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static botobo.core.domain.tag.QTag.tag;
+import static botobo.core.domain.workbook.QWorkbook.workbook;
+import static botobo.core.domain.workbooktag.QWorkbookTag.workbookTag;
+
+@RequiredArgsConstructor
+@Repository
+public class TagFilterRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Tag> findAllByContainsWorkbookName(@Param("workbookName") String workbookName) {
+        QueryResults<Tag> results = jpaQueryFactory.selectFrom(tag)
+                .innerJoin(tag.workbookTags, workbookTag).fetchJoin()
+                .innerJoin(workbookTag.workbook, workbook)
+                .where(containWorkbookName(workbookName))
+                .fetchResults();
+        return results.getResults();
+    }
+
+    private BooleanExpression containWorkbookName(String workbookName) {
+        if (workbookName == null) {
+            return null;
+        }
+        return workbook
+                .name
+                .lower()
+                .contains(workbookName.toLowerCase());
+    }
+
+
+}

--- a/backend/src/main/java/botobo/core/domain/tag/TagRepository.java
+++ b/backend/src/main/java/botobo/core/domain/tag/TagRepository.java
@@ -14,7 +14,4 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     @Query("select t from Tag t where t.tagName.value like %:keyword%")
     List<Tag> findAllTagContaining(@Param("keyword") String keyword);
 
-    @Query("select distinct t from Tag t join fetch t.workbookTags wt " +
-            "where lower(wt.workbook.name) like %:workbookName%")
-    List<Tag> findAllByContainsWorkbookName(@Param("workbookName") String workbookName);
 }

--- a/backend/src/main/java/botobo/core/domain/user/UserFilterRepository.java
+++ b/backend/src/main/java/botobo/core/domain/user/UserFilterRepository.java
@@ -1,0 +1,49 @@
+package botobo.core.domain.user;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static botobo.core.domain.card.QCard.card;
+import static botobo.core.domain.user.QUser.user;
+import static botobo.core.domain.workbook.QWorkbook.workbook;
+import static java.util.Collections.emptyList;
+
+@RequiredArgsConstructor
+@Repository
+public class UserFilterRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<User> findAllByContainsWorkbookName(String workbookName) {
+        if (Objects.isNull(workbookName)) {
+            return emptyList();
+        }
+
+        return jpaQueryFactory.selectFrom(user)
+                .distinct()
+                .innerJoin(user.workbooks, workbook)
+                .innerJoin(workbook.cards.cards, card)
+                .where(containsWorkbookName(workbookName),
+                        isOpened())
+                .fetch();
+    }
+
+    private BooleanExpression containsWorkbookName(String workbookName) {
+        return workbook
+                .name
+                .lower()
+                .contains(workbookName.toLowerCase(Locale.ROOT));
+    }
+
+    private BooleanExpression isOpened() {
+        return workbook
+                .opened
+                .isTrue();
+    }
+}

--- a/backend/src/main/java/botobo/core/domain/user/UserRepository.java
+++ b/backend/src/main/java/botobo/core/domain/user/UserRepository.java
@@ -1,10 +1,7 @@
 package botobo.core.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -14,7 +11,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByIdAndRole(Long id, Role role);
 
     Optional<User> findBySocialIdAndSocialType(String socialId, SocialType socialType);
-
-    @Query("select distinct u from User u join fetch u.workbooks w where lower(w.name) like %:workbookName% ")
-    List<User> findAllByContainsWorkbookName(@Param("workbookName") String workbook);
 }

--- a/backend/src/main/java/botobo/core/domain/user/UserRepository.java
+++ b/backend/src/main/java/botobo/core/domain/user/UserRepository.java
@@ -15,7 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 
-    @Query("select distinct u from User u join fetch u.workbooks w " +
-            "where lower(w.name) like %:workbookName%")
+    @Query("select distinct u from User u join fetch u.workbooks w where lower(w.name) like %:workbookName% ")
     List<User> findAllByContainsWorkbookName(@Param("workbookName") String workbook);
 }

--- a/backend/src/main/java/botobo/core/exception/common/ErrorType.java
+++ b/backend/src/main/java/botobo/core/exception/common/ErrorType.java
@@ -29,7 +29,6 @@ import botobo.core.exception.user.SocialTypeNotFoundException;
 import botobo.core.exception.user.UserNameDuplicatedException;
 import botobo.core.exception.user.UserNotFoundException;
 import botobo.core.exception.user.s3.ImageExtensionNotAllowedException;
-import botobo.core.exception.user.s3.S3UploadFailedException;
 import botobo.core.exception.workbook.NotOpenedWorkbookException;
 import botobo.core.exception.workbook.WorkbookNameBlankException;
 import botobo.core.exception.workbook.WorkbookNameLengthException;

--- a/backend/src/test/java/botobo/core/acceptance/DomainAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/acceptance/DomainAcceptanceTest.java
@@ -175,6 +175,16 @@ public class DomainAcceptanceTest extends AcceptanceTest {
         return 유저_문제집_등록되어_있음(workbookRequest, accessToken);
     }
 
+    protected void 유저_태그_카드_포함_문제집_등록되어_있음(String name, boolean opened, List<TagRequest> tags, String accessToken) {
+        WorkbookRequest workbookRequest = WorkbookRequest.builder()
+                .name(name)
+                .opened(opened)
+                .tags(tags)
+                .build();
+        final WorkbookResponse workbookResponse = 유저_문제집_등록되어_있음(workbookRequest, accessToken);
+        유저_카드_등록되어_있음("질문", "답변", workbookResponse.getId(), accessToken);
+    }
+
     protected WorkbookResponse 유저_문제집_등록되어_있음(WorkbookRequest workbookRequest, String accessToken) {
         return 유저_문제집_생성_요청(workbookRequest, accessToken).convertBody(WorkbookResponse.class);
     }

--- a/backend/src/test/java/botobo/core/acceptance/tag/TagAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/acceptance/tag/TagAcceptanceTest.java
@@ -2,15 +2,19 @@ package botobo.core.acceptance.tag;
 
 import botobo.core.acceptance.DomainAcceptanceTest;
 import botobo.core.acceptance.utils.RequestBuilder.HttpResponse;
+import botobo.core.domain.user.SocialType;
+import botobo.core.dto.tag.TagRequest;
 import botobo.core.dto.tag.TagResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static botobo.core.utils.Fixture.ADMIN_WORKBOOK_REQUESTS_WITH_TAG;
+import static botobo.core.utils.Fixture.joanne;
 import static botobo.core.utils.TestUtils.stringGenerator;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,13 +22,39 @@ public class TagAcceptanceTest extends DomainAcceptanceTest {
 
     @BeforeEach
     void setFixture() {
-        여러개_문제집_생성_요청(ADMIN_WORKBOOK_REQUESTS_WITH_TAG);
+        final String joanneToken = 소셜_로그인되어_있음(joanne, SocialType.GITHUB);
+        List<TagRequest> jsTags = Arrays.asList(
+                TagRequest.builder().id(0L).name("javascript").build(),
+                TagRequest.builder().id(0L).name("js").build()
+        );
+        유저_태그_카드_포함_문제집_등록되어_있음("Js 문제집", true, jsTags, joanneToken);
     }
 
     @DisplayName("문제집명에 해당하는 태그를 모두 가져온다. - 성공")
     @Test
     void findAllTagsByWorkbookName() {
         // given
+        final String workbookName = "Js";
+        final HttpResponse response = request()
+                .get("/api/tags?workbook=" + workbookName)
+                .build();
+
+        // when
+        List<TagResponse> tagResponses = response.convertBodyToList(TagResponse.class);
+
+        // then
+        assertThat(tagResponses).hasSize(2);
+        assertThat(tagResponses)
+                .extracting(TagResponse::getName)
+                .containsExactly("javascript", "js");
+    }
+
+    @DisplayName("문제집명이 포함된 문제집의 태그들을 가져온다. - 성공, 카드의 개수가 0개이면 가져오지 않는다.")
+    @Test
+    void findAllTagsByWorkbookNameWhenCardCountsZero() {
+        // given
+        서로_다른_관리자의_여러개_문제집_생성_요청(ADMIN_WORKBOOK_REQUESTS_WITH_TAG, ADMINS);
+
         final String workbookName = "Java";
         final HttpResponse response = request()
                 .get("/api/tags?workbook=" + workbookName)
@@ -34,11 +64,9 @@ public class TagAcceptanceTest extends DomainAcceptanceTest {
         List<TagResponse> tagResponses = response.convertBodyToList(TagResponse.class);
 
         // then
-        assertThat(tagResponses).hasSize(5);
-        assertThat(tagResponses)
-                .extracting(TagResponse::getName)
-                .containsExactly("자바", "자바스크립트", "리액트", "네트워크", "스프링");
+        assertThat(tagResponses).hasSize(0);
     }
+
 
     @DisplayName("문제집명에 해당하는 태그를 모두 가져온다. - 성공, 문제집 명이 비어있는 경우 빈 응답")
     @Test

--- a/backend/src/test/java/botobo/core/acceptance/tag/TagAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/acceptance/tag/TagAcceptanceTest.java
@@ -28,6 +28,7 @@ public class TagAcceptanceTest extends DomainAcceptanceTest {
                 TagRequest.builder().id(0L).name("js").build()
         );
         유저_태그_카드_포함_문제집_등록되어_있음("Js 문제집", true, jsTags, joanneToken);
+        유저_태그_카드_포함_문제집_등록되어_있음("Js 비공개 문제집", false, jsTags, joanneToken);
     }
 
     @DisplayName("문제집명에 해당하는 태그를 모두 가져온다. - 성공")
@@ -93,5 +94,21 @@ public class TagAcceptanceTest extends DomainAcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @DisplayName("문제집명이 포함된 문제집의 태그들을 가져온다. - 성공, 비공개 문제집이면 가져오지 않는다.")
+    @Test
+    void findAllTagsByWorkbookNameWhenPrivateWorkbook() {
+        // given
+        final String workbookName = "비공개";
+        final HttpResponse response = request()
+                .get("/api/tags?workbook=" + workbookName)
+                .build();
+
+        // when
+        List<TagResponse> tagResponses = response.convertBodyToList(TagResponse.class);
+
+        // then
+        assertThat(tagResponses).hasSize(0);
     }
 }

--- a/backend/src/test/java/botobo/core/acceptance/user/UserAcceptanceTest.java
+++ b/backend/src/test/java/botobo/core/acceptance/user/UserAcceptanceTest.java
@@ -571,6 +571,30 @@ class UserAcceptanceTest extends DomainAcceptanceTest {
                 .containsExactlyInAnyOrder("oz");
     }
 
+    @DisplayName("문제집명이 포함된 문제집의 작성자들을 가져온다. - 성공, 비공개 문제집의 경우 작성자를 가져오지 않는다.")
+    @Test
+    void findAllUsersByWorkbookNameWhenOpened() {
+        final String ozToken = 소셜_로그인되어_있음(oz, SocialType.GITHUB);
+        final String joanneToken = 소셜_로그인되어_있음(joanne, SocialType.GITHUB);
+        유저_카드_포함_문제집_등록되어_있음("Java 문제집", true, ozToken);
+        유저_카드_포함_문제집_등록되어_있음("Spring 문제집", false, joanneToken);
+
+        // given
+        final String workbookName = "문제집";
+        final HttpResponse response = request()
+                .get("/api/users?workbook=" + workbookName)
+                .build();
+
+        // when
+        final List<UserFilterResponse> userResponses = response.convertBodyToList(UserFilterResponse.class);
+
+        // then
+        assertThat(userResponses).hasSize(1);
+        assertThat(userResponses)
+                .extracting(UserFilterResponse::getName)
+                .containsExactlyInAnyOrder("oz");
+    }
+
     @DisplayName("문제집명이 포함된 문제집의 작성자들을 가져온다. - 성공, 문제집명이 비어있는 경우 빈 응답")
     @Test
     void findAllUsersByWorkbookNameIsEmpty() {

--- a/backend/src/test/java/botobo/core/application/TagServiceTest.java
+++ b/backend/src/test/java/botobo/core/application/TagServiceTest.java
@@ -147,6 +147,47 @@ class TagServiceTest {
         assertThat(tagResponses).hasSize(2);
     }
 
+    @DisplayName("문제집명이 포함된 문제집의 모든 태그를 가져온다. - 성공, 카드가 0개면 가져오지 않는다.")
+    @Test
+    void findAllTagsByWorkbookNameWithCardZero() {
+        // given
+        Tag java = Tag.of("java");
+
+        Workbook workbook = Workbook.builder()
+                .name("카드 없는 문제집")
+                .tags(Tags.of(List.of(java)))
+                .build();
+        workbookRepository.save(workbook);
+
+        FilterCriteria filterCriteria = new FilterCriteria("문제집");
+
+        // when - then
+        List<TagResponse> tagResponses = tagService.findAllTagsByWorkbookName(filterCriteria);
+
+        assertThat(tagResponses).hasSize(0);
+    }
+
+    @DisplayName("문제집명이 포함된 문제집의 모든 태그를 가져온다. - 성공, 비공개 문제집이면 가져오지 않는다.")
+    @Test
+    void findAllTagsByWorkbookNameWithPrivateWorkbook() {
+        // given
+        Tag java = Tag.of("java");
+
+        Workbook workbook = Workbook.builder()
+                .name("비공개 문제집")
+                .opened(false)
+                .tags(Tags.of(List.of(java)))
+                .build();
+        workbookRepository.save(workbook);
+
+        FilterCriteria filterCriteria = new FilterCriteria("문제집");
+
+        // when - then
+        List<TagResponse> tagResponses = tagService.findAllTagsByWorkbookName(filterCriteria);
+
+        assertThat(tagResponses).hasSize(0);
+    }
+
     @DisplayName("문제집명이 포함된 문제집의 모든 태그를 가져온다. - 성공, 빈 문자열일 경우 빈 리스트를 응답한다.")
     @Test
     void findAllTagsByWorkbookNameEmpty() {
@@ -176,6 +217,7 @@ class TagServiceTest {
     private Workbook makeWorkbookWithTwoTags(String workbookName, Tag tag) {
         Workbook workbook = Workbook.builder()
                 .name(workbookName)
+                .opened(true)
                 .tags(Tags.of(List.of(tag)))
                 .build();
         workbook.addCard(makeCard());

--- a/backend/src/test/java/botobo/core/application/TagServiceTest.java
+++ b/backend/src/test/java/botobo/core/application/TagServiceTest.java
@@ -1,5 +1,6 @@
 package botobo.core.application;
 
+import botobo.core.domain.card.Card;
 import botobo.core.domain.tag.Tag;
 import botobo.core.domain.tag.TagRepository;
 import botobo.core.domain.tag.Tags;
@@ -173,9 +174,18 @@ class TagServiceTest {
     }
 
     private Workbook makeWorkbookWithTwoTags(String workbookName, Tag tag) {
-        return Workbook.builder()
+        Workbook workbook = Workbook.builder()
                 .name(workbookName)
                 .tags(Tags.of(List.of(tag)))
+                .build();
+        workbook.addCard(makeCard());
+        return workbook;
+    }
+
+    private Card makeCard() {
+        return Card.builder()
+                .question("질문")
+                .answer("답변")
                 .build();
     }
 }

--- a/backend/src/test/java/botobo/core/domain/tag/TagRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/domain/tag/TagRepositoryTest.java
@@ -1,12 +1,15 @@
 package botobo.core.domain.tag;
 
+import botobo.core.config.QuerydslConfig;
 import botobo.core.domain.workbook.Workbook;
 import botobo.core.domain.workbook.WorkbookRepository;
+import botobo.core.domain.workbook.WorkbookSearchRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -18,10 +21,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest(showSql = false)
 @ActiveProfiles("test")
+@Import({TagFilterRepository.class, QuerydslConfig.class})
 class TagRepositoryTest {
 
     @Autowired
     private TagRepository tagRepository;
+
+    @Autowired
+    private TagFilterRepository tagFilterRepository;
 
     @Autowired
     private WorkbookRepository workbookRepository;
@@ -98,7 +105,7 @@ class TagRepositoryTest {
         initWorkbooks();
 
         // when
-        List<Tag> tags = tagRepository.findAllByContainsWorkbookName("java");
+        List<Tag> tags = tagFilterRepository.findAllByContainsWorkbookName("java");
         // then
         assertThat(tags).hasSize(6);
         assertThat(tags)

--- a/backend/src/test/java/botobo/core/domain/tag/TagRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/domain/tag/TagRepositoryTest.java
@@ -1,9 +1,9 @@
 package botobo.core.domain.tag;
 
 import botobo.core.config.QuerydslConfig;
+import botobo.core.domain.card.Card;
 import botobo.core.domain.workbook.Workbook;
 import botobo.core.domain.workbook.WorkbookRepository;
-import botobo.core.domain.workbook.WorkbookSearchRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -106,11 +106,38 @@ class TagRepositoryTest {
 
         // when
         List<Tag> tags = tagFilterRepository.findAllByContainsWorkbookName("java");
+
         // then
         assertThat(tags).hasSize(6);
         assertThat(tags)
                 .extracting(Tag::getTagNameValue)
                 .contains("java", "자바", "자바짱", "jdk", "js", "javascript");
+    }
+
+    @DisplayName("문제집명을 포함하는 문제집의 태그를 모두 가져온다. - 문제집의 카드가 0개일 때는 가져오지 않는다.")
+    @Test
+    void findAllByWorkbookNameWithCardZero() {
+        // given
+        initWorkbooks();
+
+        // when
+        List<Tag> tags = tagFilterRepository.findAllByContainsWorkbookName("카드가 없는");
+
+        // then
+        assertThat(tags).hasSize(0);
+    }
+
+    @DisplayName("문제집명을 포함하는 문제집의 태그를 모두 가져온다. - 비공개 문제집은 가져오지 않는다.")
+    @Test
+    void findAllByWorkbookNamePrivateWorkbook() {
+        // given
+        initWorkbooks();
+
+        // when
+        List<Tag> tags = tagFilterRepository.findAllByContainsWorkbookName("비공개");
+
+        // then
+        assertThat(tags).hasSize(0);
     }
 
     @DisplayName("문제집명을 포함하는 문제집의 태그를 모두 가져온다. - 성공, 일치하는 문제집 없음")
@@ -120,7 +147,19 @@ class TagRepositoryTest {
         initWorkbooks();
 
         // when
-        List<Tag> tags = tagRepository.findAllByContainsWorkbookName("babo");
+        List<Tag> tags = tagFilterRepository.findAllByContainsWorkbookName("babo");
+        // then
+        assertThat(tags).isEmpty();
+    }
+
+    @DisplayName("문제집명을 포함하는 문제집의 태그를 모두 가져온다. - 성공, 문제집 명이 null일 때 빈 리스트를 반환한다.")
+    @Test
+    void findAllByWorkbookNameNull() {
+        // given
+        initWorkbooks();
+
+        // when
+        List<Tag> tags = tagFilterRepository.findAllByContainsWorkbookName(null);
         // then
         assertThat(tags).isEmpty();
     }
@@ -135,21 +174,34 @@ class TagRepositoryTest {
         Tag javascript = Tag.of("javascript");
         Tag spring = Tag.of("Spring");
 
+        Workbook workbookWithCardZero = Workbook.builder()
+                .name("카드가 없는 문제집")
+                .tags(Tags.of(List.of(java)))
+                .build();
+
         List<Workbook> workbooks = List.of(
-                makeWorkbookWithTwoTags("Java", 자바, java),
-                makeWorkbookWithTwoTags("조앤의 Java 문제집", 자바, 자바짱),
-                makeWorkbookWithTwoTags("오즈의 Java 문제집", java, jdk),
-                makeWorkbookWithTwoTags("Javascript", javascript, js),
-                makeWorkbookWithTwoTags("Spring", spring, java)
+                makeWorkbookWithTwoTags("Java", 자바, java, true),
+                makeWorkbookWithTwoTags("조앤의 Java 문제집", 자바, 자바짱, true),
+                makeWorkbookWithTwoTags("오즈의 Java 문제집", java, jdk, true),
+                makeWorkbookWithTwoTags("Javascript", javascript, js, true),
+                makeWorkbookWithTwoTags("Spring", spring, java, true),
+                makeWorkbookWithTwoTags("비공개 문제집", spring, java, false),
+                workbookWithCardZero
         );
         workbookRepository.saveAll(workbooks);
     }
 
-    private Workbook makeWorkbookWithTwoTags(String workbookName, Tag tag1, Tag tag2) {
-        return Workbook.builder()
+    private Workbook makeWorkbookWithTwoTags(String workbookName, Tag tag1, Tag tag2, boolean opened) {
+        Workbook workbook = Workbook.builder()
                 .name(workbookName)
+                .opened(opened)
                 .tags(Tags.of(List.of(tag1, tag2)))
                 .build();
+        workbook.addCard(Card.builder()
+                .question("질문")
+                .answer("답변")
+                .build());
+        return workbook;
     }
 
     public void flushAndClear() {

--- a/backend/src/test/java/botobo/core/domain/user/UserFilterRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/domain/user/UserFilterRepositoryTest.java
@@ -1,0 +1,164 @@
+package botobo.core.domain.user;
+
+import botobo.core.config.QuerydslConfig;
+import botobo.core.domain.card.Card;
+import botobo.core.domain.workbook.Workbook;
+import botobo.core.domain.workbook.WorkbookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(showSql = false)
+@ActiveProfiles("test")
+@Import({UserFilterRepository.class, QuerydslConfig.class})
+class UserFilterRepositoryTest {
+
+    @Autowired
+    private UserFilterRepository userFilterRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private WorkbookRepository workbookRepository;
+
+    private User user1, user2, user3;
+
+    @BeforeEach
+    void setUp() {
+        user1 = User.builder()
+                .socialId("1")
+                .userName("user1")
+                .profileUrl("profile.io")
+                .role(Role.USER)
+                .socialType(SocialType.GITHUB)
+                .build();
+
+        user2 = User.builder()
+                .socialId("2")
+                .userName("user2")
+                .profileUrl("profile.io")
+                .role(Role.USER)
+                .socialType(SocialType.GITHUB)
+                .build();
+
+        user3 = User.builder()
+                .socialId("3")
+                .userName("user3")
+                .profileUrl("profile.io")
+                .role(Role.USER)
+                .socialType(SocialType.GITHUB)
+                .build();
+
+        initWorkbooks();
+    }
+
+    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공, 영어는 대소문자를 구분하지 않는다.")
+    @Test
+    void findAllByContainsWorkbookNameWhenEng() {
+        // when
+        List<Workbook> all = workbookRepository.findAll();
+        List<User> users = userFilterRepository.findAllByContainsWorkbookName("java");
+
+        // then
+        assertThat(users).hasSize(2);
+    }
+
+    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공, 일치하는 문제집 없음.")
+    @Test
+    void findAllByContainsWorkbookNameWhenEmptyResult() {
+        // when
+        List<User> users = userFilterRepository.findAllByContainsWorkbookName("바보");
+
+        // then
+        assertThat(users).isEmpty();
+    }
+
+    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공")
+    @Test
+    void findAllByContainsWorkbookName() {
+        // when
+        List<User> users = userFilterRepository.findAllByContainsWorkbookName("문제집");
+
+        // then
+        assertThat(users).hasSize(2);
+    }
+
+    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공, 카드가 없는 경우는 조회하지 않는다.")
+    @Test
+    void findAllByContainsWorkbookNameWhenCardsEmpty() {
+        // when
+        List<User> users = userFilterRepository.findAllByContainsWorkbookName("문제집");
+
+        // then
+        assertThat(users).hasSize(2);
+    }
+
+    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공, 비공개 문제집은 조회하지 않는다.")
+    @Test
+    void findAllByContainsWorkbookNameWhenOpened() {
+        // when
+        List<User> users = userFilterRepository.findAllByContainsWorkbookName("문제집");
+
+        // then
+        assertThat(users).hasSize(2);
+    }
+
+    private void initWorkbooks() {
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+
+        List<Workbook> workbooks = List.of(
+                makeWorkbookWithUser("자바문제집", user1),
+                makeWorkbookWithUser("자바스크립트 문제집", user2),
+                makeWorkbookWithUser("basic of java", user3),
+                makeWorkbookWithUser("면접 질문 모음집", user1),
+                makeWorkbookWithUser("JAVAscript cheatsheet", user2),
+                makeWorkbookWithUser("리액트 기초 다루기", user3)
+        );
+
+        Workbook 카드없는문제집 = Workbook.builder()
+                .name("카드 없는 문제집")
+                .user(user3)
+                .opened(true)
+                .build();
+
+        Card card = Card.builder()
+                .answer("질문")
+                .question("")
+                .build();
+        Workbook 비공개문제집 = Workbook.builder()
+                .name("비공개 문제집")
+                .user(user3)
+                .opened(false)
+                .build();
+        비공개문제집.addCard(card);
+
+        workbookRepository.saveAll(workbooks);
+        workbookRepository.save(카드없는문제집);
+        workbookRepository.save(비공개문제집);
+    }
+
+    private Workbook makeWorkbookWithUser(String workbookName, User user) {
+        Card card = Card.builder()
+                .answer("질문")
+                .question("")
+                .build();
+        Workbook workbook = Workbook.builder()
+                .name(workbookName)
+                .user(user)
+                .opened(true)
+                .build();
+        workbook.addCard(card);
+        return workbook;
+    }
+}

--- a/backend/src/test/java/botobo/core/domain/user/UserRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/domain/user/UserRepositoryTest.java
@@ -1,7 +1,5 @@
 package botobo.core.domain.user;
 
-import botobo.core.domain.workbook.Workbook;
-import botobo.core.domain.workbook.WorkbookRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,48 +18,28 @@ class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private WorkbookRepository workbookRepository;
-
-    private User user1, user2, user3;
+    private User user;
 
     @BeforeEach
     void setUp() {
-        user1 = User.builder()
+        user = User.builder()
                 .socialId("1")
                 .userName("user1")
                 .profileUrl("profile.io")
                 .role(Role.USER)
                 .socialType(SocialType.GITHUB)
                 .build();
-
-        user2 = User.builder()
-                .socialId("2")
-                .userName("user2")
-                .profileUrl("profile.io")
-                .role(Role.USER)
-                .socialType(SocialType.GITHUB)
-                .build();
-
-        user3 = User.builder()
-                .socialId("3")
-                .userName("user3")
-                .profileUrl("profile.io")
-                .role(Role.USER)
-                .socialType(SocialType.GITHUB)
-                .build();
-
     }
 
     @Test
     @DisplayName("User 저장 - 성공")
     void save() {
         // when
-        User savedUser = userRepository.save(user1);
+        User savedUser = userRepository.save(user);
 
         // then
         assertThat(savedUser.getId()).isNotNull();
-        assertThat(savedUser).isSameAs(user1);
+        assertThat(savedUser).isSameAs(user);
         assertThat(savedUser.getCreatedAt()).isNotNull();
         assertThat(savedUser.getUpdatedAt()).isNotNull();
         assertThat(savedUser.getBio()).isEqualTo("");
@@ -72,7 +49,7 @@ class UserRepositoryTest {
     @DisplayName("User id로 조회 - 성공")
     void findById() {
         // given
-        User savedUser = userRepository.save(user1);
+        User savedUser = userRepository.save(user);
 
         // when, then
         Optional<User> findUser = userRepository.findById(savedUser.getId());
@@ -83,84 +60,21 @@ class UserRepositoryTest {
     @DisplayName("User Social Id와 Social Type 으로 조회 - 성공")
     void findByGithubId() {
         // given
-        userRepository.save(user1);
+        userRepository.save(user);
 
         // when, then
-        Optional<User> findUser = userRepository.findBySocialIdAndSocialType(user1.getSocialId(), SocialType.GITHUB);
-        assertThat(findUser).containsSame(user1);
+        Optional<User> findUser = userRepository.findBySocialIdAndSocialType(user.getSocialId(), SocialType.GITHUB);
+        assertThat(findUser).containsSame(user);
     }
 
     @Test
     @DisplayName("UserName으로 조회 - 성공")
     void findByUserName() {
         // given
-        userRepository.save(user1);
+        userRepository.save(user);
 
         // when, then
-        Optional<User> findUser = userRepository.findByUserName(user1.getUserName());
-        assertThat(findUser).containsSame(user1);
-    }
-
-    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공")
-    @Test
-    void findAllByContainsWorkbookName() {
-        // given
-        initWorkbooks();
-
-        // when
-        List<User> users = userRepository.findAllByContainsWorkbookName("문제집");
-
-        // then
-        assertThat(users).hasSize(2);
-    }
-
-    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공, 영어는 대소문자를 구분하지 않는다.")
-    @Test
-    void findAllByContainsWorkbookNameWhenEng() {
-        // given
-        initWorkbooks();
-
-        // when
-        List<User> users = userRepository.findAllByContainsWorkbookName("java");
-
-        // then
-        assertThat(users).hasSize(2);
-    }
-
-    @DisplayName("문제집명을 포함한 문제집의 유저를 모두 가져온다. - 성공, 일치하는 문제집 없음.")
-    @Test
-    void findAllByContainsWorkbookNameWhenEmptyResult() {
-        // given
-        initWorkbooks();
-
-        // when
-        List<User> users = userRepository.findAllByContainsWorkbookName("바보");
-
-        // then
-        assertThat(users).isEmpty();
-    }
-
-    private void initWorkbooks() {
-        userRepository.save(user1);
-        userRepository.save(user2);
-        userRepository.save(user3);
-
-        List<Workbook> workbooks = List.of(
-                makeWorkbookWithUser("자바문제집", user1),
-                makeWorkbookWithUser("자바스크립트 문제집", user2),
-                makeWorkbookWithUser("basic of java", user3),
-                makeWorkbookWithUser("면접 질문 모음집", user1),
-                makeWorkbookWithUser("JAVAscript cheatsheet", user2),
-                makeWorkbookWithUser("리액트 기초 다루기", user3)
-        );
-
-        workbookRepository.saveAll(workbooks);
-    }
-
-    private Workbook makeWorkbookWithUser(String workbookName, User user) {
-        return Workbook.builder()
-                .name(workbookName)
-                .user(user)
-                .build();
+        Optional<User> findUser = userRepository.findByUserName(user.getUserName());
+        assertThat(findUser).containsSame(user);
     }
 }

--- a/backend/src/test/java/botobo/core/domain/workbook/WorkbookSearchRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/domain/workbook/WorkbookSearchRepositoryTest.java
@@ -147,7 +147,7 @@ class WorkbookSearchRepositoryTest {
         assertThat(workbookList).hasSize(3);
         assertThat(workbookList).extracting(Workbook::getName)
                 .containsExactly("Javascript 문제집2",
-                "Javascript 문제집1", "Javascript 문제집0");
+                        "Javascript 문제집1", "Javascript 문제집0");
     }
 
     @Test
@@ -167,7 +167,7 @@ class WorkbookSearchRepositoryTest {
         assertThat(workbookList).hasSize(3);
         assertThat(workbookList).extracting(Workbook::getName)
                 .containsExactly("Javascript 문제집0",
-                "Javascript 문제집1", "Javascript 문제집2");
+                        "Javascript 문제집1", "Javascript 문제집2");
     }
 
     @Test
@@ -187,7 +187,7 @@ class WorkbookSearchRepositoryTest {
         assertThat(workbookList).hasSize(3);
         assertThat(workbookList).extracting(Workbook::getName)
                 .containsExactly("Javascript 문제집0",
-                "Javascript 문제집1", "Javascript 문제집2");
+                        "Javascript 문제집1", "Javascript 문제집2");
     }
 
     @Test
@@ -207,12 +207,12 @@ class WorkbookSearchRepositoryTest {
         assertThat(workbookList).hasSize(7);
         assertThat(workbookList).extracting(Workbook::getName)
                 .containsExactly("좋아요가 많아 문제다.",
-                "Java 문제집0",
-                "Javascript 문제집0",
-                "Java 문제집1",
-                "Javascript 문제집1",
-                "Java 문제집2",
-                "Javascript 문제집2");
+                        "Java 문제집0",
+                        "Javascript 문제집0",
+                        "Java 문제집1",
+                        "Javascript 문제집1",
+                        "Java 문제집2",
+                        "Javascript 문제집2");
     }
 
     @Test

--- a/backend/src/test/java/botobo/core/infrastructure/FileNameGeneratorTest.java
+++ b/backend/src/test/java/botobo/core/infrastructure/FileNameGeneratorTest.java
@@ -1,8 +1,8 @@
 package botobo.core.infrastructure;
 
-import botobo.core.infrastructure.s3.UploadFile;
 import botobo.core.exception.user.s3.ImageExtensionNotAllowedException;
 import botobo.core.infrastructure.s3.FileNameGenerator;
+import botobo.core.infrastructure.s3.UploadFile;
 import botobo.core.utils.FileFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
closes #529 

## 작업 내용
- 필터에서 조회되는 유저와 태그가 문제집의 카드가 0개일 때는 조회되지 않도록 수정했습니다.
- opened가 false일 때도 조회되던걸 수정했습니다.
~- jpql로 쿼리를 날려서 해결하려고 했는데 생각보다 복잡해서 다 받아오고 UserServie와 TagService에서 걸러주도록 만들었습니다.~
~- 후에 QueryDSL로 변경하거나 다시 jpql을 좀 더 생각해서 코드를 변경할 예정입니다.~
- UserRepository, TagRepository에 있던 문제집명에 포함되는 엔티티를 가져오는 find 메서드를 QueryDSL Repository로 이동시키고 구현했습니다.


## 주의 사항
- 없음