### PR TITLE
B01 - 연관 태그 검색 queryDsl에서 DTO를 사용하도록 리팩터링한다. 

### DIFF
--- a/backend/src/main/java/botobo/core/application/SearchService.java
+++ b/backend/src/main/java/botobo/core/application/SearchService.java
@@ -4,6 +4,7 @@ import botobo.core.application.rank.SearchRankService;
 import botobo.core.domain.tag.Tag;
 import botobo.core.domain.tag.TagSearchRepository;
 import botobo.core.domain.tag.Tags;
+import botobo.core.domain.tag.dto.TagDto;
 import botobo.core.domain.workbook.Workbook;
 import botobo.core.domain.workbook.WorkbookSearchRepository;
 import botobo.core.dto.tag.TagResponse;
@@ -56,8 +57,9 @@ public class SearchService {
         if (target.isBlank()) {
             return TagResponse.listOf(Tags.empty());
         }
-        List<Tag> tags = tagSearchRepository.findAllTagContaining(target);
-        List<Tag> sortedTags = SimilarityChecker.orderBySimilarity(target, tags, SIZE_LIMIT);
-        return TagResponse.listOf(Tags.of(sortedTags));
+        List<TagDto> tags = tagSearchRepository.findAllTagContaining(target);
+        List<TagDto> sortedTags = SimilarityChecker.orderBySimilarity(target, tags, SIZE_LIMIT);
+        return TagResponse.listOf(sortedTags);
     }
+
 }

--- a/backend/src/main/java/botobo/core/domain/tag/TagSearchRepository.java
+++ b/backend/src/main/java/botobo/core/domain/tag/TagSearchRepository.java
@@ -1,6 +1,8 @@
 package botobo.core.domain.tag;
 
 
+import botobo.core.domain.tag.dto.TagDto;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,13 +25,16 @@ public class TagSearchRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<Tag> findAllTagContaining(String keyword) {
+    public List<TagDto> findAllTagContaining(String keyword) {
         if (Objects.isNull(keyword)) {
             return Collections.emptyList();
         }
 
-        return jpaQueryFactory.selectFrom(tag)
-                .distinct()
+        return jpaQueryFactory.from(tag)
+                .select(Projections.constructor(TagDto.class,
+                        tag.id,
+                        tag.tagName.value
+                )).distinct()
                 .innerJoin(tag.workbookTags, workbookTag)
                 .innerJoin(workbookTag.workbook, workbook)
                 .innerJoin(workbook.cards.cards, card)

--- a/backend/src/main/java/botobo/core/domain/tag/dto/TagDto.java
+++ b/backend/src/main/java/botobo/core/domain/tag/dto/TagDto.java
@@ -1,0 +1,20 @@
+package botobo.core.domain.tag.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TagDto {
+    private Long id;
+    private String name;
+
+    public static TagDto of (Long id, String name) {
+        return new TagDto(id, name);
+    }
+
+    public TagDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/botobo/core/dto/tag/TagResponse.java
+++ b/backend/src/main/java/botobo/core/dto/tag/TagResponse.java
@@ -2,6 +2,7 @@ package botobo.core.dto.tag;
 
 import botobo.core.domain.tag.Tag;
 import botobo.core.domain.tag.Tags;
+import botobo.core.domain.tag.dto.TagDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,8 +29,21 @@ public class TagResponse implements Serializable {
                 .build();
     }
 
+    public static TagResponse of(TagDto tag) {
+        return TagResponse.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .build();
+    }
+
     public static List<TagResponse> listOf(Tags tags) {
         return tags.stream()
+                .map(TagResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public static List<TagResponse> listOf(List<TagDto> tagDtos) {
+        return tagDtos.stream()
                 .map(TagResponse::of)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/botobo/core/util/SimilarityChecker.java
+++ b/backend/src/main/java/botobo/core/util/SimilarityChecker.java
@@ -1,7 +1,7 @@
 package botobo.core.util;
 
 import botobo.core.domain.tag.Tag;
-import botobo.core.domain.tag.TagName;
+import botobo.core.domain.tag.dto.TagDto;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,10 +13,10 @@ public class SimilarityChecker {
     private SimilarityChecker() {
     }
 
-    public static List<Tag> orderBySimilarity(String origin, List<Tag> target, int sizeLimit) {
+    public static List<TagDto> orderBySimilarity(String origin, List<TagDto> target, int sizeLimit) {
         List<Pair> tempList = new ArrayList<>();
-        for (Tag tag : target) {
-            int score = similarity(origin, tag.getTagName());
+        for (TagDto tag : target) {
+            int score = similarity(origin, tag.getName());
             tempList.add(new Pair(tag, score));
         }
         return tempList.stream()
@@ -34,17 +34,17 @@ public class SimilarityChecker {
             return 1;
         }
         if (previous.score == next.score) {
-            return previous.getTag().compareToIgnoreCase(next.getTag());
+            return previous.getName().compareToIgnoreCase(next.getName());
         }
         return previous.score > next.score ? 1 : -1;
     }
 
     private static boolean tagNameStartsWith(Pair previous, String origin) {
-        return previous.getTag().startsWith(origin);
+        return previous.getName().startsWith(origin);
     }
 
-    private static int similarity(String s1, TagName tagName) {
-        String s2 = tagName.getValue();
+    private static int similarity(String s1, String name) {
+        String s2 = name;
         s1 = s1.toLowerCase();
         s2 = s2.toLowerCase();
         int[] scores = new int[s2.length() + 1];
@@ -77,16 +77,16 @@ public class SimilarityChecker {
     }
 
     private static class Pair {
-        Tag tag;
+        TagDto tag;
         int score;
 
-        public Pair(Tag tag, int score) {
+        public Pair(TagDto tag, int score) {
             this.tag = tag;
             this.score = score;
         }
 
-        public String getTag() {
-            return tag.getTagNameValue();
+        public String getName() {
+            return tag.getName();
         }
     }
 }

--- a/backend/src/test/java/botobo/core/application/SearchServiceTest.java
+++ b/backend/src/test/java/botobo/core/application/SearchServiceTest.java
@@ -1,15 +1,17 @@
 package botobo.core.application;
 
 import botobo.core.application.rank.SearchRankService;
-import botobo.core.domain.tag.Tag;
 import botobo.core.domain.tag.TagSearchRepository;
+import botobo.core.domain.tag.dto.TagDto;
 import botobo.core.domain.workbook.Workbook;
 import botobo.core.domain.workbook.WorkbookSearchRepository;
 import botobo.core.dto.tag.TagResponse;
 import botobo.core.ui.search.SearchRelated;
 import botobo.core.ui.search.WorkbookSearchParameter;
 import botobo.core.utils.WorkbookSearchParameterUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -45,59 +47,63 @@ class SearchServiceTest {
     @InjectMocks
     private SearchService searchService;
 
-    @Test
-    @DisplayName("태그 검색 - 성공, 이름에 키워드가 들어가면 결과에 포함된다")
-    void searchTags() {
-        // given
-        String java = "java";
-        String javascript = "javascript";
-        List<Tag> tags = List.of(Tag.of(java), Tag.of(javascript));
-        given(tagRepository.findAllTagContaining(java)).willReturn(tags);
+    @Nested
+    @DisplayName("태그 검색")
+    class TagSearch {
+        private static final String JAVA = "java";
+        private static final String JAVASCRIPT = "javascript";
+        private List<TagDto> tags;
 
-        // when
-        List<TagResponse> tagResponses = searchService.findTagsIn(new SearchRelated(java));
+        @BeforeEach
+        void setUp() {
+            tags = List.of(TagDto.of(1L, JAVA), TagDto.of(2L, JAVASCRIPT));
+        }
 
-        // then
-        then(tagRepository).should(times(1))
-                .findAllTagContaining(java);
-        assertThat(tagResponses).extracting("name").containsExactly(java, javascript);
-    }
+        @Test
+        @DisplayName("성공, 이름에 키워드가 들어가면 결과에 포함된다")
+        void searchTags() {
+            // given
+            given(tagRepository.findAllTagContaining(JAVA)).willReturn(tags);
 
-    @Test
-    @DisplayName("대문자로 태그 검색 - 성공, 태그 검색은 대소문자를 구별하지 않는다")
-    void searchTagsWithUpperCaseIncluded() {
-        // given
-        String java = "java";
-        String javascript = "javascript";
-        List<Tag> tags = List.of(Tag.of(java), Tag.of(javascript));
-        given(tagRepository.findAllTagContaining(java)).willReturn(tags);
+            // when
+            List<TagResponse> tagResponses = searchService.findTagsIn(new SearchRelated(JAVA));
 
-        // when
-        List<TagResponse> tagResponses = searchService.findTagsIn(new SearchRelated("JAVA"));
+            // then
+            then(tagRepository).should(times(1))
+                    .findAllTagContaining(JAVA);
+            assertThat(tagResponses).extracting("name").containsExactly(JAVA, JAVASCRIPT);
+        }
 
-        // then
-        then(tagRepository).should(times(1))
-                .findAllTagContaining(java);
-        assertThat(tagResponses).extracting("name").containsExactly(java, javascript);
-    }
+        @Test
+        @DisplayName("성공, 태그 검색은 대소문자를 구별하지 않는다")
+        void searchTagsWithUpperCaseIncluded() {
+            // given
+            given(tagRepository.findAllTagContaining(JAVA)).willReturn(tags);
 
-    @Test
-    @DisplayName("태그 검색 - 성공, 양 쪽 빈칸은 trim 된다.")
-    void searchTagsWhenHasEmptySpace() {
-        // given
-        String keyword = " java ";
-        String java = "java";
-        String javascript = "javascript";
-        List<Tag> tags = List.of(Tag.of(java), Tag.of(javascript));
-        given(tagRepository.findAllTagContaining(java)).willReturn(tags);
+            // when
+            List<TagResponse> tagResponses = searchService.findTagsIn(new SearchRelated("JAVA"));
 
-        // when
-        List<TagResponse> tagResponses = searchService.findTagsIn(new SearchRelated(keyword));
+            // then
+            then(tagRepository).should(times(1))
+                    .findAllTagContaining(JAVA);
+            assertThat(tagResponses).extracting("name").containsExactly(JAVA, JAVASCRIPT);
+        }
 
-        // then
-        then(tagRepository).should(times(1))
-                .findAllTagContaining(java);
-        assertThat(tagResponses).extracting("name").containsExactly(java, javascript);
+        @Test
+        @DisplayName("성공, 양 쪽 빈칸은 trim 된다.")
+        void searchTagsWhenHasEmptySpace() {
+            // given
+            String keyword = " java ";
+            given(tagRepository.findAllTagContaining(JAVA)).willReturn(tags);
+
+            // when
+            List<TagResponse> tagResponses = searchService.findTagsIn(new SearchRelated(keyword));
+
+            // then
+            then(tagRepository).should(times(1))
+                    .findAllTagContaining(JAVA);
+            assertThat(tagResponses).extracting("name").containsExactly(JAVA, JAVASCRIPT);
+        }
     }
 
     @Test

--- a/backend/src/test/java/botobo/core/domain/tag/TagSearchRepositoryTest.java
+++ b/backend/src/test/java/botobo/core/domain/tag/TagSearchRepositoryTest.java
@@ -2,6 +2,7 @@ package botobo.core.domain.tag;
 
 import botobo.core.config.QuerydslConfig;
 import botobo.core.domain.FilterRepositoryTest;
+import botobo.core.domain.tag.dto.TagDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,7 +73,7 @@ class TagSearchRepositoryTest extends FilterRepositoryTest {
     @DisplayName("keyword에 포함된 태그 조회 - 성공")
     void findAllTagsIn() {
         // when
-        List<Tag> tags = tagSearchRepository.findAllTagContaining("자바");
+        List<TagDto> tags = tagSearchRepository.findAllTagContaining("자바");
 
         // then
         assertThat(tags).hasSize(2);
@@ -82,7 +83,7 @@ class TagSearchRepositoryTest extends FilterRepositoryTest {
     @DisplayName("keyword에 포함된 태그 조회 - 성공, 비공개 문제집에 포함된 태그는 포함되지 않는다.")
     void findAllTagsWhenIncludeInPrivateWorkbook() {
         // when
-        List<Tag> tags = tagSearchRepository.findAllTagContaining("private");
+        List<TagDto> tags = tagSearchRepository.findAllTagContaining("private");
 
         // then
         assertThat(tags).isEmpty();
@@ -92,7 +93,7 @@ class TagSearchRepositoryTest extends FilterRepositoryTest {
     @DisplayName("keyword에 포함된 태그 조회 - 성공, 카드가 0개인 문제집은 포함되지 않는다.")
     void findAllTagsWhenEmptyCards() {
         // when
-        List<Tag> tags = tagSearchRepository.findAllTagContaining("empty");
+        List<TagDto> tags = tagSearchRepository.findAllTagContaining("empty");
 
         // then
         assertThat(tags).isEmpty();
@@ -102,7 +103,7 @@ class TagSearchRepositoryTest extends FilterRepositoryTest {
     @DisplayName("keyword에 포함된 태그 조회 - keyword가 null인 경우 빈 리스트를 응답한다.")
     void findAllTagsContainingWhenKeywordIsNull() {
         // when
-        List<Tag> tags = tagSearchRepository.findAllTagContaining(null);
+        List<TagDto> tags = tagSearchRepository.findAllTagContaining(null);
 
         // then
         assertThat(tags).isEmpty();

--- a/backend/src/test/java/botobo/core/util/SimilarityCheckerTest.java
+++ b/backend/src/test/java/botobo/core/util/SimilarityCheckerTest.java
@@ -1,6 +1,7 @@
 package botobo.core.util;
 
 import botobo.core.domain.tag.Tag;
+import botobo.core.domain.tag.dto.TagDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,24 +16,24 @@ class SimilarityCheckerTest {
     @Test
     void orderBySimilarity() {
         // given
-        List<Tag> tags = List.of(
-                Tag.of("나무자바"),
-                Tag.of("자바스크립트 문제집"),
-                Tag.of("자바스"),
-                Tag.of("자바리자바"),
-                Tag.of("자바"),
-                Tag.of("자바스크립트"),
-                Tag.of("자바를 잡아라"),
-                Tag.of("공자바")
+        List<TagDto> tags = List.of(
+                TagDto.of(1L, "나무자바"),
+                TagDto.of(2L, "자바스크립트 문제집"),
+                TagDto.of(3L, "자바스"),
+                TagDto.of(4L, "자바리자바"),
+                TagDto.of(5L, "자바"),
+                TagDto.of(6L, "자바스크립트"),
+                TagDto.of(7L, "자바를 잡아라"),
+                TagDto.of(8L, "공자바")
         );
 
         // when
-        List<Tag> orderBySimilarity = SimilarityChecker.orderBySimilarity("자바", tags, 5);
+        List<TagDto> orderBySimilarity = SimilarityChecker.orderBySimilarity("자바", tags, 5);
 
         // then
         assertThat(orderBySimilarity).hasSize(5);
         assertThat(orderBySimilarity.stream()
-                .map(Tag::getTagNameValue)
+                .map(TagDto::getName)
                 .collect(Collectors.toList()))
                 .containsExactly("자바", "자바스", "자바리자바", "자바스크립트", "자바를 잡아라");
     }
@@ -41,22 +42,22 @@ class SimilarityCheckerTest {
     @Test
     void orderBySimilarityEng() {
         // given
-        List<Tag> tags = List.of(
-                Tag.of("java"),
-                Tag.of("javascript"),
-                Tag.of("java11"),
-                Tag.of("aajava"),
-                Tag.of("bbjava"),
-                Tag.of("ozjava"),
-                Tag.of("javajoanne")
+        List<TagDto> tags = List.of(
+                TagDto.of(1L, "java"),
+                TagDto.of(2L, "javascript"),
+                TagDto.of(3L, "java11"),
+                TagDto.of(4L, "aajava"),
+                TagDto.of(5L, "bbjava"),
+                TagDto.of(6L, "ozjava"),
+                TagDto.of(7L, "javajoanne")
         );
 
         // when
-        List<Tag> orderBySimilarity = SimilarityChecker.orderBySimilarity("java", tags, 5);
+        List<TagDto> orderBySimilarity = SimilarityChecker.orderBySimilarity("java", tags, 5);
         // then
         assertThat(orderBySimilarity).hasSize(5);
         assertThat(orderBySimilarity.stream()
-                .map(Tag::getTagNameValue)
+                .map(TagDto::getName)
                 .collect(Collectors.toList()))
                 .containsExactly("java", "java11", "javajoanne", "javascript", "aajava");
     }


### PR DESCRIPTION
closes #608 

## 작업 내용
연관 태그 검색 QueryDsl에서 TagDto를 사용해 필요한 정보만 받아오도록 수정했습니다.

## 주의 사항
TagResponse와 필드가 동일한데, repository <-> 서비스 레이어에서 사용하는 DTO라서 우선은 따로 분리했습니다. 