### PR TITLE
fix: Mariadb querydsl function.random 쿼리 동작하지 않아서 수정

### DIFF
--- a/backend/src/main/java/botobo/core/domain/workbook/WorkbookQueryRepository.java
+++ b/backend/src/main/java/botobo/core/domain/workbook/WorkbookQueryRepository.java
@@ -7,6 +7,7 @@ import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -39,7 +40,7 @@ public class WorkbookQueryRepository {
         return jpaQueryFactory.selectFrom(workbook)
                 .innerJoin(workbook.cards.cards, card).fetchJoin()
                 .where(openedTrue())
-                .orderBy(NumberExpression.random().asc())
+                .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
                 .groupBy(workbook.id)
                 .limit(100)
                 .fetch();


### PR DESCRIPTION
## 작업 내용
https://github.com/querydsl/querydsl/issues/1881

## 주의 사항